### PR TITLE
Graph ingestion: evidence-bound entities and relations (#49)

### DIFF
--- a/docs/spec/system_elf_memory_service_v2.md
+++ b/docs/spec/system_elf_memory_service_v2.md
@@ -926,15 +926,55 @@ Body:
       "importance": 0.0,
       "confidence": 0.0,
       "ttl_days": 180,
+      "structured": {
+        "summary": "string|null",
+        "facts": "string[]|null",
+        "concepts": "string[]|null",
+        "entities": [
+          {
+            "canonical": "string|null",
+            "kind": "string|null",
+            "aliases": "string[]|null"
+          }
+        ]|null,
+        "relations": [
+          {
+            "subject": {
+              "canonical": "string|null",
+              "kind": "string|null",
+              "aliases": "string[]|null"
+            },
+            "predicate": "string",
+            "object": {
+              "entity": {
+                "canonical": "string|null",
+                "kind": "string|null",
+                "aliases": "string[]|null"
+              }|null,
+              "value": "string|null"
+            },
+            "valid_from": "ISO8601 datetime|null",
+            "valid_to": "ISO8601 datetime|null"
+          }
+        ]|null
+      }|null,
       "source_ref": { ... }
     }
   ]
 }
 
+Notes:
+- Exactly one of object.entity and object.value must be non-null.
+
 Response:
 {
   "results": [
-    { "note_id": "uuid|null", "op": "ADD|UPDATE|NONE|DELETE|REJECTED", "reason_code": "optional" }
+    {
+      "note_id": "uuid|null",
+      "op": "ADD|UPDATE|NONE|DELETE|REJECTED",
+      "reason_code": "optional",
+      "field_path": "optional"
+    }
   ]
 }
 
@@ -959,7 +999,13 @@ Response:
 {
   "extracted": { ...extractor output... },
   "results": [
-    { "note_id": "uuid|null", "op": "ADD|UPDATE|NONE|DELETE|REJECTED", "reason_code": "optional", "reason": "optional" }
+    {
+      "note_id": "uuid|null",
+      "op": "ADD|UPDATE|NONE|DELETE|REJECTED",
+      "reason_code": "optional",
+      "reason": "optional",
+      "field_path": "optional"
+    }
   ]
 }
 
@@ -1187,6 +1233,38 @@ Schema:
       "importance": 0.0,
       "confidence": 0.0,
       "ttl_days": number|null,
+      "structured": {
+        "summary": "string|null",
+        "facts": "string[]|null",
+        "concepts": "string[]|null",
+        "entities": [
+          {
+            "canonical": "string|null",
+            "kind": "string|null",
+            "aliases": "string[]|null"
+          }
+        ]|null,
+        "relations": [
+          {
+            "subject": {
+              "canonical": "string|null",
+              "kind": "string|null",
+              "aliases": "string[]|null"
+            },
+            "predicate": "string",
+            "object": {
+              "entity": {
+                "canonical": "string|null",
+                "kind": "string|null",
+                "aliases": "string[]|null"
+              }|null,
+              "value": "string|null"
+            },
+            "valid_from": "ISO8601 datetime|null",
+            "valid_to": "ISO8601 datetime|null"
+          }
+        ]|null
+      }|null,
       "scope_suggestion": "agent_private|project_shared|org_shared|null",
       "evidence": [
         { "message_index": number, "quote": "string" }
@@ -1195,6 +1273,9 @@ Schema:
     }
   ]
 }
+
+Notes:
+- Exactly one of object.entity and object.value must be non-null.
 
 Hard rules:
 - notes.length <= MAX_NOTES

--- a/docs/spec/system_graph_memory_postgres_v1.md
+++ b/docs/spec/system_graph_memory_postgres_v1.md
@@ -103,6 +103,7 @@ Indexes:
   - lowercase
 - An active fact is defined by: `valid_from <= now AND (valid_to IS NULL OR valid_to > now)`.
 - Active duplicate prevention is enforced by partial unique indexes.
+- When ingestion reintroduces a note equivalent to an existing active fact, the system reuses the existing fact row and appends additional evidence rows for the new note instead of creating another active duplicate fact row.
 
 ============================================================
 5. CALL EXAMPLES

--- a/packages/elf-service/src/graph.rs
+++ b/packages/elf-service/src/graph.rs
@@ -1,7 +1,7 @@
 use time::OffsetDateTime;
 use uuid::Uuid;
 
-use crate::Result;
+use crate::{ElfService, Result};
 use elf_storage::graph;
 
 #[allow(dead_code)]
@@ -19,7 +19,7 @@ pub(crate) struct GraphUpsertFactArgs<'a> {
 	pub evidence_note_ids: &'a [Uuid],
 }
 
-impl crate::ElfService {
+impl ElfService {
 	#[allow(dead_code)]
 	pub(crate) async fn graph_upsert_fact(&self, args: GraphUpsertFactArgs<'_>) -> Result<Uuid> {
 		let mut tx = self.db.pool.begin().await?;

--- a/packages/elf-service/src/graph_ingestion.rs
+++ b/packages/elf-service/src/graph_ingestion.rs
@@ -1,0 +1,140 @@
+use sqlx::{Postgres, Transaction};
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+use crate::{Error, StructuredFields, structured_fields::StructuredEntity};
+use elf_storage::graph;
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn persist_graph_fields_tx(
+	tx: &mut Transaction<'_, Postgres>,
+	tenant_id: &str,
+	project_id: &str,
+	agent_id: &str,
+	scope: &str,
+	note_id: Uuid,
+	structured: &StructuredFields,
+	now: OffsetDateTime,
+) -> crate::Result<()> {
+	if !structured.has_graph_fields() {
+		return Ok(());
+	}
+
+	if let Some(entities) = structured.entities.as_ref() {
+		for (entity_idx, entity) in entities.iter().enumerate() {
+			let base_path = format!("structured.entities[{entity_idx}]");
+			upsert_graph_entity_and_aliases(tx, tenant_id, project_id, entity, base_path.as_str())
+				.await?;
+		}
+	}
+
+	let relations = structured.relations.as_deref().unwrap_or_default();
+	for (relation_idx, relation) in relations.iter().enumerate() {
+		let relation_path = format!("structured.relations[{relation_idx}]");
+		let subject = relation.subject.as_ref().ok_or_else(|| Error::InvalidRequest {
+			message: format!("{relation_path}.subject is required."),
+		})?;
+		let predicate = relation.predicate.as_deref().ok_or_else(|| Error::InvalidRequest {
+			message: format!("{relation_path}.predicate is required."),
+		})?;
+
+		let subject_entity_id = upsert_graph_entity_and_aliases(
+			tx,
+			tenant_id,
+			project_id,
+			subject,
+			&format!("{relation_path}.subject"),
+		)
+		.await?;
+
+		let valid_from = relation.valid_from.unwrap_or(now);
+		let valid_to = relation.valid_to;
+		if let Some(valid_to) = valid_to
+			&& valid_to <= valid_from
+		{
+			return Err(Error::InvalidRequest {
+				message: format!("{relation_path}.valid_to must be greater than valid_from."),
+			});
+		}
+
+		let object = relation.object.as_ref().ok_or_else(|| Error::InvalidRequest {
+			message: format!("{relation_path}.object is required."),
+		})?;
+
+		let (object_entity_id, object_value) = match (&object.entity, &object.value) {
+			(Some(entity), None) => {
+				let entity_id = upsert_graph_entity_and_aliases(
+					tx,
+					tenant_id,
+					project_id,
+					entity,
+					&format!("{relation_path}.object.entity"),
+				)
+				.await?;
+				(Some(entity_id), None)
+			},
+			(None, Some(value)) => (None, Some(value.as_str())),
+			_ => {
+				return Err(Error::InvalidRequest {
+					message: format!(
+						"{relation_path}.object must provide exactly one of entity or value.",
+					),
+				});
+			},
+		};
+
+		graph::upsert_fact_with_evidence(
+			tx,
+			tenant_id,
+			project_id,
+			agent_id,
+			scope,
+			subject_entity_id,
+			predicate,
+			object_entity_id,
+			object_value,
+			valid_from,
+			valid_to,
+			&[note_id],
+		)
+		.await
+		.map_err(|err| Error::Storage { message: err.to_string() })?;
+	}
+
+	Ok(())
+}
+
+async fn upsert_graph_entity_and_aliases(
+	tx: &mut Transaction<'_, Postgres>,
+	tenant_id: &str,
+	project_id: &str,
+	entity: &StructuredEntity,
+	context_path: &str,
+) -> crate::Result<Uuid> {
+	let canonical = entity.canonical.as_deref().ok_or_else(|| Error::InvalidRequest {
+		message: format!("{context_path}.canonical is required."),
+	})?;
+
+	let canonical = canonical.trim();
+	let entity_id =
+		graph::upsert_entity(tx, tenant_id, project_id, canonical, entity.kind.as_deref())
+			.await
+			.map_err(|err| Error::Storage { message: err.to_string() })?;
+
+	if let Some(aliases) = entity.aliases.as_ref() {
+		for (alias_idx, alias) in aliases.iter().enumerate() {
+			let alias = alias.trim();
+			if alias.is_empty() {
+				return Err(Error::InvalidRequest {
+					message: format!("{context_path}.aliases[{alias_idx}] must not be empty."),
+				});
+			}
+
+			graph::upsert_entity_alias(tx, entity_id, alias)
+				.await
+				.map_err(|err| Error::Storage { message: err.to_string() })?;
+		}
+	}
+
+	Ok(entity_id)
+}

--- a/packages/elf-service/src/lib.rs
+++ b/packages/elf-service/src/lib.rs
@@ -12,6 +12,7 @@ pub mod time_serde;
 pub mod update;
 
 mod error;
+mod graph_ingestion;
 mod ranking_explain_v2;
 
 pub use self::{

--- a/packages/elf-service/tests/acceptance/graph_ingestion.rs
+++ b/packages/elf-service/tests/acceptance/graph_ingestion.rs
@@ -1,0 +1,544 @@
+use std::{
+	collections::hash_map::DefaultHasher,
+	hash::{Hash, Hasher},
+	sync::{Arc, atomic::AtomicUsize},
+};
+
+use uuid::Uuid;
+
+use elf_service::{
+	AddEventRequest, AddNoteInput, AddNoteRequest, EmbeddingProvider, EventMessage, NoteOp,
+	Providers,
+};
+
+struct HashEmbedding {
+	vector_dim: u32,
+}
+
+impl EmbeddingProvider for HashEmbedding {
+	fn embed<'a>(
+		&'a self,
+		_: &'a elf_config::EmbeddingProviderConfig,
+		texts: &'a [String],
+	) -> elf_service::BoxFuture<'a, elf_service::Result<Vec<Vec<f32>>>> {
+		let vector_dim = self.vector_dim as usize;
+		let vectors = texts
+			.iter()
+			.map(|text| {
+				let mut values = Vec::with_capacity(vector_dim);
+
+				for idx in 0..vector_dim {
+					let mut hasher = DefaultHasher::new();
+					text.hash(&mut hasher);
+					idx.hash(&mut hasher);
+					let raw = hasher.finish();
+					let normalized = ((raw % 2_000_000) as f32 / 1_000_000.0) - 1.0;
+					values.push(normalized);
+				}
+
+				values
+			})
+			.collect();
+
+		Box::pin(async move { Ok(vectors) })
+	}
+}
+
+#[tokio::test]
+#[ignore = "Requires external Postgres and Qdrant. Set ELF_PG_DSN and ELF_QDRANT_URL to run."]
+async fn add_note_duplicate_fact_attaches_multiple_evidence() {
+	let Some(test_db) = crate::acceptance::test_db().await else {
+		eprintln!(
+			"Skipping add_note_duplicate_fact_attaches_multiple_evidence; set ELF_PG_DSN to run.",
+		);
+
+		return;
+	};
+	let Some(qdrant_url) = crate::acceptance::test_qdrant_url() else {
+		eprintln!(
+			"Skipping add_note_duplicate_fact_attaches_multiple_evidence; set ELF_QDRANT_URL to run.",
+		);
+
+		return;
+	};
+
+	let providers = Providers::new(
+		Arc::new(HashEmbedding { vector_dim: 4_096 }),
+		Arc::new(crate::acceptance::StubRerank),
+		Arc::new(crate::acceptance::SpyExtractor {
+			calls: Arc::new(AtomicUsize::new(0)),
+			payload: serde_json::json!({ "notes": [] }),
+		}),
+	);
+	let collection = test_db.collection_name("elf_acceptance");
+	let cfg =
+		crate::acceptance::test_config(test_db.dsn().to_string(), qdrant_url, 4_096, collection);
+	let service =
+		crate::acceptance::build_service(cfg, providers).await.expect("Failed to build service.");
+
+	crate::acceptance::reset_db(&service.db.pool).await.expect("Failed to reset test database.");
+
+	let response = service
+		.add_note(AddNoteRequest {
+			tenant_id: "t".to_string(),
+			project_id: "p".to_string(),
+			agent_id: "a".to_string(),
+			scope: "agent_private".to_string(),
+			notes: vec![
+				AddNoteInput {
+					r#type: "fact".to_string(),
+					key: Some("mentorship-a".to_string()),
+					text: "Alice mentors Bob in 2026.".to_string(),
+					structured: Some(
+						serde_json::from_value::<elf_service::structured_fields::StructuredFields>(
+							serde_json::json!({
+								"relations": [{
+									"subject": { "canonical": "Alice" },
+									"predicate": "mentors",
+									"object": { "value": "Bob" }
+								}]
+							}),
+						)
+						.expect("Failed to build structured fields."),
+					),
+					importance: 0.8,
+					confidence: 0.9,
+					ttl_days: None,
+					source_ref: serde_json::json!({}),
+				},
+				AddNoteInput {
+					r#type: "fact".to_string(),
+					key: Some("mentorship-b".to_string()),
+					text: "Alice also mentors Bob often.".to_string(),
+					structured: Some(
+						serde_json::from_value::<elf_service::structured_fields::StructuredFields>(
+							serde_json::json!({
+								"relations": [{
+									"subject": { "canonical": "Alice" },
+									"predicate": "mentors",
+									"object": { "value": "Bob" }
+								}]
+							}),
+						)
+						.expect("Failed to build structured fields."),
+					),
+					importance: 0.7,
+					confidence: 0.8,
+					ttl_days: None,
+					source_ref: serde_json::json!({}),
+				},
+			],
+		})
+		.await
+		.expect("add_note failed.");
+
+	assert_eq!(response.results.len(), 2);
+	assert_eq!(response.results[0].op, NoteOp::Add);
+	assert_eq!(response.results[1].op, NoteOp::Add);
+	let first_note_id = response.results[0].note_id.expect("Expected note_id.");
+	let second_note_id = response.results[1].note_id.expect("Expected note_id.");
+	assert_ne!(first_note_id, second_note_id);
+
+	let fact_id: Uuid = sqlx::query_scalar(
+		"\
+SELECT gf.fact_id
+FROM graph_facts gf
+JOIN graph_entities ge ON ge.entity_id = gf.subject_entity_id
+WHERE ge.canonical_norm = $1
+	AND gf.predicate = $2
+	AND gf.object_value = $3
+	AND gf.tenant_id = $4
+	AND gf.project_id = $5
+	AND gf.scope = $6",
+	)
+	.bind("alice")
+	.bind("mentors")
+	.bind("Bob")
+	.bind("t")
+	.bind("p")
+	.bind("agent_private")
+	.fetch_one(&service.db.pool)
+	.await
+	.expect("Failed to load fact.");
+
+	let fact_count: i64 = sqlx::query_scalar(
+		"\
+SELECT COUNT(*)
+FROM graph_facts gf
+JOIN graph_entities ge ON ge.entity_id = gf.subject_entity_id
+WHERE ge.canonical_norm = $1
+	AND gf.predicate = $2
+	AND gf.object_value = $3
+	AND gf.tenant_id = $4
+	AND gf.project_id = $5
+	AND gf.scope = $6",
+	)
+	.bind("alice")
+	.bind("mentors")
+	.bind("Bob")
+	.bind("t")
+	.bind("p")
+	.bind("agent_private")
+	.fetch_one(&service.db.pool)
+	.await
+	.expect("Failed to count fact rows.");
+
+	let evidence_count: i64 =
+		sqlx::query_scalar("SELECT COUNT(*) FROM graph_fact_evidence WHERE fact_id = $1")
+			.bind(fact_id)
+			.fetch_one(&service.db.pool)
+			.await
+			.expect("Failed to load fact evidence.");
+
+	assert_eq!(fact_count, 1);
+	assert_eq!(evidence_count, 2);
+
+	let first_evidence_count: i64 = sqlx::query_scalar(
+		"SELECT COUNT(*) FROM graph_fact_evidence WHERE fact_id = $1 AND note_id = $2",
+	)
+	.bind(fact_id)
+	.bind(first_note_id)
+	.fetch_one(&service.db.pool)
+	.await
+	.expect("Failed to load first note evidence.");
+	let second_evidence_count: i64 = sqlx::query_scalar(
+		"SELECT COUNT(*) FROM graph_fact_evidence WHERE fact_id = $1 AND note_id = $2",
+	)
+	.bind(fact_id)
+	.bind(second_note_id)
+	.fetch_one(&service.db.pool)
+	.await
+	.expect("Failed to load second note evidence.");
+
+	assert_eq!(first_evidence_count, 1);
+	assert_eq!(second_evidence_count, 1);
+
+	test_db.cleanup().await.expect("Failed to cleanup test database.");
+}
+
+#[tokio::test]
+#[ignore = "Requires external Postgres and Qdrant. Set ELF_PG_DSN and ELF_QDRANT_URL to run."]
+async fn add_note_invalid_relation_rejected_has_field_path() {
+	let Some(test_db) = crate::acceptance::test_db().await else {
+		eprintln!(
+			"Skipping add_note_invalid_relation_rejected_has_field_path; set ELF_PG_DSN to run."
+		);
+
+		return;
+	};
+	let Some(qdrant_url) = crate::acceptance::test_qdrant_url() else {
+		eprintln!(
+			"Skipping add_note_invalid_relation_rejected_has_field_path; set ELF_QDRANT_URL to run.",
+		);
+
+		return;
+	};
+
+	let providers = Providers::new(
+		Arc::new(crate::acceptance::StubEmbedding { vector_dim: 4_096 }),
+		Arc::new(crate::acceptance::StubRerank),
+		Arc::new(crate::acceptance::SpyExtractor {
+			calls: Arc::new(AtomicUsize::new(0)),
+			payload: serde_json::json!({ "notes": [] }),
+		}),
+	);
+	let collection = test_db.collection_name("elf_acceptance");
+	let cfg =
+		crate::acceptance::test_config(test_db.dsn().to_string(), qdrant_url, 4_096, collection);
+	let service =
+		crate::acceptance::build_service(cfg, providers).await.expect("Failed to build service.");
+
+	let response = service
+		.add_note(AddNoteRequest {
+			tenant_id: "t".to_string(),
+			project_id: "p".to_string(),
+			agent_id: "a".to_string(),
+			scope: "agent_private".to_string(),
+			notes: vec![AddNoteInput {
+				r#type: "fact".to_string(),
+				key: Some("mentorship".to_string()),
+				text: "Alice mentors Bob.".to_string(),
+				structured: Some(
+					serde_json::from_value::<elf_service::structured_fields::StructuredFields>(
+						serde_json::json!({
+							"relations": [{
+								"subject": { "canonical": "Alice" },
+								"object": { "value": "Bob" }
+							}]
+						}),
+					)
+					.expect("Failed to build structured fields."),
+				),
+				importance: 0.8,
+				confidence: 0.9,
+				ttl_days: None,
+				source_ref: serde_json::json!({}),
+			}],
+		})
+		.await
+		.expect("add_note failed.");
+
+	assert_eq!(response.results.len(), 1);
+	assert_eq!(response.results[0].op, NoteOp::Rejected);
+	assert_eq!(response.results[0].reason_code.as_deref(), Some("REJECT_STRUCTURED_INVALID"));
+	assert_eq!(
+		response.results[0].field_path,
+		Some("structured.relations[0].predicate".to_string()),
+	);
+
+	test_db.cleanup().await.expect("Failed to cleanup test database.");
+}
+
+#[tokio::test]
+#[ignore = "Requires external Postgres and Qdrant. Set ELF_PG_DSN and ELF_QDRANT_URL to run."]
+async fn add_note_persists_graph_relations() {
+	let Some(test_db) = crate::acceptance::test_db().await else {
+		eprintln!("Skipping add_note_persists_graph_relations; set ELF_PG_DSN to run.");
+
+		return;
+	};
+	let Some(qdrant_url) = crate::acceptance::test_qdrant_url() else {
+		eprintln!("Skipping add_note_persists_graph_relations; set ELF_QDRANT_URL to run.");
+
+		return;
+	};
+
+	let providers = Providers::new(
+		Arc::new(crate::acceptance::StubEmbedding { vector_dim: 4_096 }),
+		Arc::new(crate::acceptance::StubRerank),
+		Arc::new(crate::acceptance::SpyExtractor {
+			calls: Arc::new(AtomicUsize::new(0)),
+			payload: serde_json::json!({ "notes": [] }),
+		}),
+	);
+	let collection = test_db.collection_name("elf_acceptance");
+	let cfg =
+		crate::acceptance::test_config(test_db.dsn().to_string(), qdrant_url, 4_096, collection);
+	let service =
+		crate::acceptance::build_service(cfg, providers).await.expect("Failed to build service.");
+
+	crate::acceptance::reset_db(&service.db.pool).await.expect("Failed to reset test database.");
+
+	let response = service
+		.add_note(AddNoteRequest {
+			tenant_id: "t".to_string(),
+			project_id: "p".to_string(),
+			agent_id: "a".to_string(),
+			scope: "agent_private".to_string(),
+			notes: vec![AddNoteInput {
+				r#type: "fact".to_string(),
+				key: Some("mentorship".to_string()),
+				text: "Alice mentors Bob.".to_string(),
+				structured: Some(
+					serde_json::from_value::<elf_service::structured_fields::StructuredFields>(
+						serde_json::json!({
+								"relations": [{
+									"subject": { "canonical": "Alice" },
+									"predicate": "mentors",
+									"object": { "value": "Bob" }
+							}]
+						}),
+					)
+					.expect("Failed to build structured fields."),
+				),
+				importance: 0.8,
+				confidence: 0.9,
+				ttl_days: None,
+				source_ref: serde_json::json!({}),
+			}],
+		})
+		.await
+		.expect("add_note failed.");
+
+	assert_eq!(response.results.len(), 1);
+	assert_eq!(response.results[0].op, NoteOp::Add);
+	let note_id = response.results[0].note_id.expect("Expected note_id.");
+
+	let fact_id: Uuid = sqlx::query_scalar(
+		"\
+SELECT gf.fact_id
+FROM graph_facts gf
+JOIN graph_entities ge ON ge.entity_id = gf.subject_entity_id
+WHERE ge.canonical_norm = $1
+	AND gf.predicate = $2
+	AND gf.object_value = $3
+	AND gf.tenant_id = $4
+	AND gf.project_id = $5
+	AND gf.scope = $6",
+	)
+	.bind("alice")
+	.bind("mentors")
+	.bind("Bob")
+	.bind("t")
+	.bind("p")
+	.bind("agent_private")
+	.fetch_one(&service.db.pool)
+	.await
+	.expect("Failed to load fact.");
+
+	let fact_count: i64 = sqlx::query_scalar(
+		"\
+SELECT COUNT(*)
+FROM graph_facts gf
+JOIN graph_entities ge ON ge.entity_id = gf.subject_entity_id
+WHERE ge.canonical_norm = $1
+	AND gf.predicate = $2
+	AND gf.object_value = $3
+	AND gf.tenant_id = $4
+	AND gf.project_id = $5
+	AND gf.scope = $6",
+	)
+	.bind("alice")
+	.bind("mentors")
+	.bind("Bob")
+	.bind("t")
+	.bind("p")
+	.bind("agent_private")
+	.fetch_one(&service.db.pool)
+	.await
+	.expect("Failed to count fact rows.");
+
+	let evidence_count: i64 = sqlx::query_scalar(
+		"SELECT COUNT(*) FROM graph_fact_evidence WHERE fact_id = $1 AND note_id = $2",
+	)
+	.bind(fact_id)
+	.bind(note_id)
+	.fetch_one(&service.db.pool)
+	.await
+	.expect("Failed to load fact evidence.");
+
+	assert_eq!(fact_count, 1);
+	assert_eq!(evidence_count, 1);
+
+	test_db.cleanup().await.expect("Failed to cleanup test database.");
+}
+
+#[tokio::test]
+#[ignore = "Requires external Postgres and Qdrant. Set ELF_PG_DSN and ELF_QDRANT_URL to run."]
+async fn add_event_persists_graph_relations() {
+	let Some(test_db) = crate::acceptance::test_db().await else {
+		eprintln!("Skipping add_event_persists_graph_relations; set ELF_PG_DSN to run.");
+
+		return;
+	};
+	let Some(qdrant_url) = crate::acceptance::test_qdrant_url() else {
+		eprintln!("Skipping add_event_persists_graph_relations; set ELF_QDRANT_URL to run.");
+
+		return;
+	};
+
+	let extractor_payload = serde_json::json!({
+		"notes": [{
+			"type": "fact",
+			"key": "mentorship",
+			"text": "Alice mentors Bob.",
+			"structured": {
+				"relations": [{
+					"subject": { "canonical": "Alice" },
+					"predicate": "mentors",
+					"object": { "value": "Bob" }
+				}]
+			},
+			"importance": 0.8,
+			"confidence": 0.9,
+			"ttl_days": null,
+			"scope_suggestion": "agent_private",
+			"evidence": [{ "message_index": 0, "quote": "Alice mentors Bob." }],
+			"reason": "test"
+		}]
+	});
+	let providers = Providers::new(
+		Arc::new(crate::acceptance::StubEmbedding { vector_dim: 4_096 }),
+		Arc::new(crate::acceptance::StubRerank),
+		Arc::new(crate::acceptance::SpyExtractor {
+			calls: Arc::new(AtomicUsize::new(0)),
+			payload: extractor_payload,
+		}),
+	);
+	let collection = test_db.collection_name("elf_acceptance");
+	let cfg =
+		crate::acceptance::test_config(test_db.dsn().to_string(), qdrant_url, 4_096, collection);
+	let service =
+		crate::acceptance::build_service(cfg, providers).await.expect("Failed to build service.");
+
+	crate::acceptance::reset_db(&service.db.pool).await.expect("Failed to reset test database.");
+
+	let response = service
+		.add_event(AddEventRequest {
+			tenant_id: "t".to_string(),
+			project_id: "p".to_string(),
+			agent_id: "a".to_string(),
+			scope: Some("agent_private".to_string()),
+			dry_run: Some(false),
+			messages: vec![EventMessage {
+				role: "user".to_string(),
+				content: "Alice mentors Bob.".to_string(),
+				ts: None,
+				msg_id: None,
+			}],
+		})
+		.await
+		.expect("add_event failed.");
+
+	assert_eq!(response.results.len(), 1);
+	assert_eq!(response.results[0].op, NoteOp::Add);
+	let note_id = response.results[0].note_id.expect("Expected note_id.");
+
+	let fact_id: Uuid = sqlx::query_scalar(
+		"\
+SELECT gf.fact_id
+FROM graph_facts gf
+JOIN graph_entities ge ON ge.entity_id = gf.subject_entity_id
+WHERE ge.canonical_norm = $1
+	AND gf.predicate = $2
+	AND gf.object_value = $3
+	AND gf.tenant_id = $4
+	AND gf.project_id = $5
+	AND gf.scope = $6",
+	)
+	.bind("alice")
+	.bind("mentors")
+	.bind("Bob")
+	.bind("t")
+	.bind("p")
+	.bind("agent_private")
+	.fetch_one(&service.db.pool)
+	.await
+	.expect("Failed to load fact.");
+
+	let fact_count: i64 = sqlx::query_scalar(
+		"\
+SELECT COUNT(*)
+FROM graph_facts gf
+JOIN graph_entities ge ON ge.entity_id = gf.subject_entity_id
+WHERE ge.canonical_norm = $1
+	AND gf.predicate = $2
+	AND gf.object_value = $3
+	AND gf.tenant_id = $4
+	AND gf.project_id = $5
+	AND gf.scope = $6",
+	)
+	.bind("alice")
+	.bind("mentors")
+	.bind("Bob")
+	.bind("t")
+	.bind("p")
+	.bind("agent_private")
+	.fetch_one(&service.db.pool)
+	.await
+	.expect("Failed to count fact rows.");
+
+	let evidence_count: i64 = sqlx::query_scalar(
+		"SELECT COUNT(*) FROM graph_fact_evidence WHERE fact_id = $1 AND note_id = $2",
+	)
+	.bind(fact_id)
+	.bind(note_id)
+	.fetch_one(&service.db.pool)
+	.await
+	.expect("Failed to load fact evidence.");
+
+	assert_eq!(fact_count, 1);
+	assert_eq!(evidence_count, 1);
+
+	test_db.cleanup().await.expect("Failed to cleanup test database.");
+}

--- a/packages/elf-service/tests/acceptance/suite.rs
+++ b/packages/elf-service/tests/acceptance/suite.rs
@@ -3,6 +3,7 @@ mod chunk_search;
 mod chunking;
 mod english_only_boundary;
 mod evidence_binding;
+mod graph_ingestion;
 mod idempotency;
 mod outbox_eventual_consistency;
 mod rebuild_qdrant;


### PR DESCRIPTION
Implements #49 (depends on #64): extend ingestion to support evidence-bound entities/relations and persist them into the graph tables.

Key changes
- API/contract: `structured.entities` + `structured.relations` on add_note, and extractor output supports the same on add_event.
- Validation: strict evidence binding for relation subject/predicate/object; optional per-note `field_path` surfaced on `REJECT_STRUCTURED_INVALID`.
- Persistence: upserts graph entities/aliases and active facts; duplicates attach evidence via conflict-safe upsert (no aborted transactions).
- Tests/docs: acceptance coverage for graph ingestion + duplicate evidence; spec docs updated.

Verification
- `cargo make fmt-rust-check`
- `cargo make lint`
- `cargo make test-rust`
- `set -a && source .env && set +a && cargo make test-integration`
- `set -a && source .env && set +a && ELF_QDRANT_HTTP_URL=http://127.0.0.1:51889 cargo make e2e`
