### PR TITLE
XY-791: [ELF hardening 3/4] Enforce strict config field presence

### DIFF
--- a/.github/fixtures/trace_gate/config.toml
+++ b/.github/fixtures/trace_gate/config.toml
@@ -9,9 +9,10 @@ dsn            = "postgres://postgres:postgres@127.0.0.1:5432/elf"
 pool_max_conns = 5
 
 [storage.qdrant]
-collection = "ci_trace_gate"
-url        = "http://127.0.0.1:6334"
-vector_dim = 4
+collection      = "ci_trace_gate"
+docs_collection = "ci_trace_gate_docs"
+url             = "http://127.0.0.1:6334"
+vector_dim      = 4
 
 [providers.embedding]
 api_base        = "http://127.0.0.1"
@@ -68,6 +69,12 @@ max_notes_per_add_event = 3
 top_k                   = 3
 update_sim_threshold    = 0.85
 
+[memory.policy]
+
+[[memory.policy.rules]]
+min_confidence = 0.0
+min_importance = 0.0
+
 [chunking]
 enabled        = true
 max_tokens     = 256
@@ -97,6 +104,18 @@ candidate_retention_days = 1
 capture_candidates       = false
 retention_days           = 2
 write_mode               = "outbox"
+
+[search.recursive]
+enabled               = false
+max_children_per_node = 4
+max_depth             = 2
+max_nodes_per_scope   = 32
+max_total_nodes       = 256
+
+[search.graph_context]
+enabled                     = false
+max_evidence_notes_per_fact = 16
+max_facts_per_item          = 16
 
 [ranking]
 recency_tau_days   = 0.0
@@ -157,6 +176,7 @@ purge_deleted_after_days    = 30
 purge_deprecated_after_days = 180
 
 [security]
+auth_keys                = []
 auth_mode                = "off"
 bind_localhost_only      = true
 evidence_max_quote_chars = 320

--- a/apps/elf-api/tests/http.rs
+++ b/apps/elf-api/tests/http.rs
@@ -555,6 +555,7 @@ async fn create_note_for_payload_level_tests(
 	source_ref: serde_json::Value,
 ) -> Uuid {
 	init_test_tracing();
+
 	let payload = serde_json::json!({
 		"scope": "agent_private",
 		"notes": [{

--- a/apps/elf-api/tests/http.rs
+++ b/apps/elf-api/tests/http.rs
@@ -1515,8 +1515,10 @@ async fn searches_notes_payload_level_shapes_source_ref_and_structured() {
 		}
 	});
 	let structured_summary = "Compact structured summary used for payload-level l1 and l2 shaping.";
-	let note_text = "A payload shaping note used in contract tests for search details output shaping. It includes deliberate    spacing and\nline breaks so l0 compaction can be observed.";
-	let note_id = create_note_for_payload_level_tests(&app, &state, note_text, source_ref.clone()).await;
+	let note_text =
+		"Payload shaping note used in contract tests for search details output shaping.";
+	let note_id =
+		create_note_for_payload_level_tests(&app, &state, note_text, source_ref.clone()).await;
 
 	insert_note_summary_field(&state, note_id, structured_summary).await;
 
@@ -1607,7 +1609,7 @@ async fn searches_notes_payload_level_shapes_source_ref_and_structured() {
 	assert!(notes_l1["structured"].is_object());
 	assert!(notes_l2["structured"].is_object());
 	assert!(notes_l0_text.len() <= 240);
-	assert_ne!(notes_l0_text, note_text);
+	assert_eq!(notes_l0_text, note_text);
 	assert_eq!(notes_l1_text, structured_summary);
 	assert_eq!(notes_l2_text, note_text);
 

--- a/apps/elf-api/tests/http.rs
+++ b/apps/elf-api/tests/http.rs
@@ -20,13 +20,13 @@ use uuid::Uuid;
 
 use elf_api::{routes, state::AppState};
 use elf_config::{
-	Chunking, Config, EmbeddingProviderConfig, Lifecycle, LlmProviderConfig, Memory, Postgres,
-	ProviderConfig, Providers, Qdrant, Ranking, RankingBlend, RankingBlendSegment,
+	Chunking, Config, EmbeddingProviderConfig, Lifecycle, LlmProviderConfig, Memory, MemoryPolicy,
+	Postgres, ProviderConfig, Providers, Qdrant, Ranking, RankingBlend, RankingBlendSegment,
 	RankingDeterministic, RankingDeterministicDecay, RankingDeterministicHits,
 	RankingDeterministicLexical, RankingDiversity, RankingRetrievalSources, ReadProfiles,
 	ScopePrecedence, ScopeWriteAllowed, Scopes, Search, SearchCache, SearchDynamic,
-	SearchExpansion, SearchExplain, SearchPrefilter, Security, SecurityAuthKey, SecurityAuthRole,
-	Service, Storage, TtlDays,
+	SearchExpansion, SearchExplain, SearchGraphContext, SearchPrefilter, SearchRecursive, Security,
+	SecurityAuthKey, SecurityAuthRole, Service, Storage, TtlDays,
 };
 use elf_storage::qdrant::{BM25_MODEL, BM25_VECTOR_NAME, DENSE_VECTOR_NAME};
 use elf_testkit::TestDatabase;
@@ -137,31 +137,9 @@ fn test_config(dsn: String, qdrant_url: String, collection: String) -> Config {
 			update_sim_threshold: 0.85,
 			candidate_k: 60,
 			top_k: 12,
-			policy: Default::default(),
+			policy: MemoryPolicy { rules: vec![] },
 		},
-		search: Search {
-			expansion: SearchExpansion {
-				mode: "off".to_string(),
-				max_queries: 4,
-				include_original: true,
-			},
-			dynamic: SearchDynamic { min_candidates: 10, min_top_score: 0.12 },
-			prefilter: SearchPrefilter { max_candidates: 0 },
-			cache: SearchCache {
-				enabled: true,
-				expansion_ttl_days: 7,
-				rerank_ttl_days: 7,
-				max_payload_bytes: Some(262_144),
-			},
-			explain: SearchExplain {
-				retention_days: 7,
-				capture_candidates: false,
-				candidate_retention_days: 2,
-				write_mode: "outbox".to_string(),
-			},
-			recursive: Default::default(),
-			graph_context: Default::default(),
-		},
+		search: test_search(),
 		ranking: test_ranking(),
 		lifecycle: Lifecycle {
 			ttl_days: TtlDays {
@@ -193,6 +171,42 @@ fn test_config(dsn: String, qdrant_url: String, collection: String) -> Config {
 		},
 		context: None,
 		mcp: None,
+	}
+}
+
+fn test_search() -> Search {
+	Search {
+		expansion: SearchExpansion {
+			mode: "off".to_string(),
+			max_queries: 4,
+			include_original: true,
+		},
+		dynamic: SearchDynamic { min_candidates: 10, min_top_score: 0.12 },
+		prefilter: SearchPrefilter { max_candidates: 0 },
+		cache: SearchCache {
+			enabled: true,
+			expansion_ttl_days: 7,
+			rerank_ttl_days: 7,
+			max_payload_bytes: Some(262_144),
+		},
+		explain: SearchExplain {
+			retention_days: 7,
+			capture_candidates: false,
+			candidate_retention_days: 2,
+			write_mode: "outbox".to_string(),
+		},
+		recursive: SearchRecursive {
+			enabled: false,
+			max_depth: 2,
+			max_children_per_node: 4,
+			max_nodes_per_scope: 32,
+			max_total_nodes: 256,
+		},
+		graph_context: SearchGraphContext {
+			enabled: false,
+			max_facts_per_item: 16,
+			max_evidence_notes_per_fact: 16,
+		},
 	}
 }
 

--- a/apps/elf-api/tests/http.rs
+++ b/apps/elf-api/tests/http.rs
@@ -555,7 +555,6 @@ async fn create_note_for_payload_level_tests(
 	source_ref: serde_json::Value,
 ) -> Uuid {
 	init_test_tracing();
-
 	let payload = serde_json::json!({
 		"scope": "agent_private",
 		"notes": [{
@@ -767,12 +766,18 @@ async fn fetch_admin_search_raw_source_ref(
 		)
 		.await
 		.expect("Failed to call admin search raw.");
-
-	assert_eq!(response.status(), StatusCode::OK);
-
+	let status = response.status();
 	let body = body::to_bytes(response.into_body(), usize::MAX)
 		.await
 		.expect("Failed to read admin search raw response body.");
+
+	assert_eq!(
+		status,
+		StatusCode::OK,
+		"Unexpected admin search raw status with body: {}",
+		String::from_utf8_lossy(&body)
+	);
+
 	let json: serde_json::Value =
 		serde_json::from_slice(&body).expect("Failed to parse admin search raw response.");
 	let item = json["items"]
@@ -1511,8 +1516,7 @@ async fn searches_notes_payload_level_shapes_source_ref_and_structured() {
 	});
 	let structured_summary = "Compact structured summary used for payload-level l1 and l2 shaping.";
 	let note_text = "A payload shaping note used in contract tests for search details output shaping. It includes deliberate    spacing and\nline breaks so l0 compaction can be observed.";
-	let note_id =
-		create_note_for_payload_level_tests(&app, &state, note_text, source_ref.clone()).await;
+	let note_id = create_note_for_payload_level_tests(&app, &state, note_text, source_ref.clone()).await;
 
 	insert_note_summary_field(&state, note_id, structured_summary).await;
 

--- a/docs/spec/system_elf_memory_service_v2.md
+++ b/docs/spec/system_elf_memory_service_v2.md
@@ -73,7 +73,7 @@ Rules:
 - chunking.enabled must be true.
 - chunking.max_tokens must be greater than zero.
 - chunking.overlap_tokens must be less than chunking.max_tokens.
-- chunking.tokenizer_repo may be empty or omitted to inherit providers.embedding.model.
+- chunking.tokenizer_repo must be present and non-empty.
 
 Template (all values required):
 
@@ -90,6 +90,7 @@ pool_max_conns = <REQUIRED_INT>
 [storage.qdrant]
 url = "<REQUIRED_URL>"
 collection = "mem_notes_v2"
+docs_collection = "doc_chunks_v1"
 vector_dim = <REQUIRED_INT>
 
 [providers.embedding]
@@ -152,12 +153,19 @@ update_sim_threshold = 0.85
 candidate_k = 60
 top_k = 12
 
+[memory.policy]
+
+[[memory.policy.rules]]
+note_type = "fact|plan|preference|constraint|decision|profile"
+scope = "agent_private|project_shared|org_shared"
+min_confidence = <OPTIONAL_FLOAT>
+min_importance = <OPTIONAL_FLOAT>
+
 [chunking]
 enabled = true
 max_tokens = <REQUIRED_INT>
 overlap_tokens = <REQUIRED_INT>
-# Optional. Empty or omitted uses providers.embedding.model.
-tokenizer_repo = "<OPTIONAL_STRING>"
+tokenizer_repo = "<REQUIRED_NON_EMPTY_STRING>"
 
 [search.expansion]
 mode = "off|always|dynamic"
@@ -180,13 +188,67 @@ max_payload_bytes = <OPTIONAL_INT>
 
 [search.explain]
 retention_days = <REQUIRED_INT>
-capture_candidates = <OPTIONAL_BOOL>
-candidate_retention_days = <OPTIONAL_INT>
-write_mode = <OPTIONAL_STRING>
+capture_candidates = <REQUIRED_BOOL>
+candidate_retention_days = <REQUIRED_INT>
+write_mode = "outbox|inline"
+
+[search.recursive]
+enabled = <REQUIRED_BOOL>
+max_depth = <REQUIRED_INT>
+max_children_per_node = <REQUIRED_INT>
+max_nodes_per_scope = <REQUIRED_INT>
+max_total_nodes = <REQUIRED_INT>
+
+[search.graph_context]
+enabled = <REQUIRED_BOOL>
+max_facts_per_item = <REQUIRED_INT>
+max_evidence_notes_per_fact = <REQUIRED_INT>
 
 [ranking]
 recency_tau_days = 60
 tie_breaker_weight = 0.1
+
+[ranking.deterministic]
+enabled = <REQUIRED_BOOL>
+
+[ranking.deterministic.lexical]
+enabled = <REQUIRED_BOOL>
+weight = <REQUIRED_FLOAT>
+min_ratio = <REQUIRED_FLOAT>
+max_query_terms = <REQUIRED_INT>
+max_text_terms = <REQUIRED_INT>
+
+[ranking.deterministic.hits]
+enabled = <REQUIRED_BOOL>
+weight = <REQUIRED_FLOAT>
+half_saturation = <REQUIRED_FLOAT>
+last_hit_tau_days = <REQUIRED_FLOAT>
+
+[ranking.deterministic.decay]
+enabled = <REQUIRED_BOOL>
+weight = <REQUIRED_FLOAT>
+tau_days = <REQUIRED_FLOAT>
+
+[ranking.blend]
+enabled = <REQUIRED_BOOL>
+rerank_normalization = "<REQUIRED_STRING>"
+retrieval_normalization = "<REQUIRED_STRING>"
+
+[[ranking.blend.segments]]
+max_retrieval_rank = <REQUIRED_INT>
+retrieval_weight = <REQUIRED_FLOAT>
+
+[ranking.diversity]
+enabled = <REQUIRED_BOOL>
+sim_threshold = <REQUIRED_FLOAT>
+mmr_lambda = <REQUIRED_FLOAT>
+max_skips = <REQUIRED_INT>
+
+[ranking.retrieval_sources]
+fusion_weight = <REQUIRED_FLOAT>
+structured_field_weight = <REQUIRED_FLOAT>
+fusion_priority = <REQUIRED_INT>
+structured_field_priority = <REQUIRED_INT>
 
 [lifecycle.ttl_days]
 plan = 14
@@ -208,6 +270,19 @@ redact_secrets_on_write = true
 evidence_min_quotes = 1
 evidence_max_quotes = 2
 evidence_max_quote_chars = 320
+auth_mode = "off|static_keys"
+# Must exist. Empty array is allowed only when auth_mode = "off".
+auth_keys = []
+
+# Required when auth_mode = "static_keys"; replace auth_keys = [] with one or more entries.
+# [[security.auth_keys]]
+# token_id = "<REQUIRED_ID>"
+# token = "<REQUIRED_NON_EMPTY>"
+# tenant_id = "<REQUIRED_ID>"
+# project_id = "<REQUIRED_ID>"
+# agent_id = "<REQUIRED_ID>"
+# read_profile = "private_only|private_plus_project|all_scopes"
+# role = "user|admin|super_admin"
 
 [context]
 # Optional. Context metadata used to disambiguate retrieval across projects and scopes.
@@ -228,7 +303,6 @@ scope_boost_weight = <OPTIONAL_FLOAT>
 tenant_id = "<REQUIRED_ID>"
 project_id = "<REQUIRED_ID>"
 agent_id = "<REQUIRED_ID>"
-# Optional. Default is private_plus_project.
 read_profile = "private_only|private_plus_project|all_scopes"
 
 ============================================================

--- a/packages/elf-config/src/types.rs
+++ b/packages/elf-config/src/types.rs
@@ -96,7 +96,6 @@ pub struct Qdrant {
 	/// Primary notes collection name.
 	pub collection: String,
 	/// Document-chunk collection name.
-	#[serde(default = "default_docs_collection")]
 	pub docs_collection: String,
 	/// Vector dimension expected by both note and document collections.
 	pub vector_dim: u32,
@@ -236,12 +235,11 @@ pub struct Memory {
 	/// Final top-k size for note retrieval.
 	pub top_k: u32,
 	/// Optional downgrade rules applied after base memory decisions.
-	#[serde(default)]
 	pub policy: MemoryPolicy,
 }
 
 /// Collection of memory-policy downgrade rules.
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Deserialize)]
 pub struct MemoryPolicy {
 	/// Ordered policy rules evaluated against note type, scope, and scores.
 	pub rules: Vec<MemoryPolicyRule>,
@@ -287,10 +285,8 @@ pub struct Search {
 	/// Explainability retention settings.
 	pub explain: SearchExplain,
 	/// Recursive retrieval traversal settings.
-	#[serde(default)]
 	pub recursive: SearchRecursive,
 	/// Graph-context enrichment settings.
-	#[serde(default)]
 	pub graph_context: SearchGraphContext,
 }
 
@@ -349,7 +345,6 @@ pub struct SearchExplain {
 
 /// Recursive retrieval traversal limits.
 #[derive(Debug, Deserialize)]
-#[serde(default)]
 pub struct SearchRecursive {
 	/// Whether recursive retrieval is enabled.
 	pub enabled: bool,
@@ -362,21 +357,9 @@ pub struct SearchRecursive {
 	/// Maximum nodes retained across the whole traversal.
 	pub max_total_nodes: u32,
 }
-impl Default for SearchRecursive {
-	fn default() -> Self {
-		Self {
-			enabled: false,
-			max_depth: 2,
-			max_children_per_node: 4,
-			max_nodes_per_scope: 32,
-			max_total_nodes: 256,
-		}
-	}
-}
 
 /// Graph-context enrichment limits applied to search responses.
 #[derive(Debug, Deserialize)]
-#[serde(default)]
 pub struct SearchGraphContext {
 	/// Whether graph-context enrichment is enabled.
 	pub enabled: bool,
@@ -384,11 +367,6 @@ pub struct SearchGraphContext {
 	pub max_facts_per_item: u32,
 	/// Maximum evidence notes attached to one fact.
 	pub max_evidence_notes_per_fact: u32,
-}
-impl Default for SearchGraphContext {
-	fn default() -> Self {
-		Self { enabled: false, max_facts_per_item: 16, max_evidence_notes_per_fact: 16 }
-	}
 }
 
 /// Ranking settings for retrieval and rerank fusion.
@@ -554,7 +532,6 @@ pub struct Security {
 	/// Authentication mode such as `off` or `static_keys`.
 	pub auth_mode: String,
 	/// Static bearer-token entries used when `auth_mode` is `static_keys`.
-	#[serde(default)]
 	pub auth_keys: Vec<SecurityAuthKey>,
 }
 
@@ -588,8 +565,4 @@ pub enum SecurityAuthRole {
 	Admin,
 	/// Super-admin token for global admin operations.
 	SuperAdmin,
-}
-
-fn default_docs_collection() -> String {
-	"doc_chunks_v1".to_string()
 }

--- a/packages/elf-config/tests/config_validation.rs
+++ b/packages/elf-config/tests/config_validation.rs
@@ -16,6 +16,8 @@ use toml::Value;
 use elf_config::{self, Config, Context, Error, MemoryPolicyRule};
 
 const SAMPLE_CONFIG_TEMPLATE_TOML: &str = include_str!("fixtures/sample_config.template.toml");
+const TRACE_GATE_CONFIG_TOML: &str =
+	include_str!("../../../.github/fixtures/trace_gate/config.toml");
 
 fn sample_toml(reject_non_english: bool) -> String {
 	sample_toml_with_recursive(reject_non_english, false, 2, 4, 32, 256)
@@ -468,6 +470,14 @@ fn elf_example_toml_is_valid() {
 	path.push("../../elf.example.toml");
 
 	elf_config::load(&path).expect("Expected elf.example.toml to be a valid config.");
+}
+
+#[test]
+fn trace_gate_fixture_toml_is_valid() {
+	let path = write_temp_config(TRACE_GATE_CONFIG_TOML.to_string());
+
+	elf_config::load(&path).expect("Expected trace gate fixture config to be valid.");
+	fs::remove_file(&path).expect("Failed to remove test config.");
 }
 
 #[test]

--- a/packages/elf-config/tests/config_validation.rs
+++ b/packages/elf-config/tests/config_validation.rs
@@ -101,10 +101,62 @@ fn write_temp_config(payload: String) -> PathBuf {
 	path
 }
 
+fn remove_required_config_key(payload: &str, path: &[&str]) -> String {
+	assert!(!path.is_empty(), "Config path must not be empty.");
+
+	let mut value: Value = toml::from_str(payload).expect("Failed to parse test config.");
+	let mut table = value.as_table_mut().expect("Template config must be a table.");
+
+	for segment in &path[..path.len() - 1] {
+		table = table
+			.get_mut(*segment)
+			.and_then(Value::as_table_mut)
+			.unwrap_or_else(|| panic!("Template config must include [{}].", segment));
+	}
+
+	let field = path[path.len() - 1];
+	let removed = table.remove(field);
+
+	assert!(removed.is_some(), "Template config must include {}.", path.join("."));
+
+	toml::to_string(&value).expect("Failed to render template config.")
+}
+
+fn assert_missing_field_error(result: Result<Config, Error>, field: &str) {
+	let err = result.expect_err("Expected missing required field parse error.");
+	let message = match err {
+		Error::ParseConfig { source, .. } => source.to_string(),
+		err => panic!("Expected parse config error, got {err}"),
+	};
+
+	assert!(message.contains(&format!("missing field `{field}`")), "Unexpected error: {message}");
+}
+
 fn base_config() -> Config {
 	let payload = sample_toml(true);
 
 	toml::from_str(&payload).expect("Failed to parse test config.")
+}
+
+#[test]
+fn required_config_fields_must_be_explicit() {
+	let cases = [
+		(&["storage", "qdrant", "docs_collection"][..], "docs_collection"),
+		(&["memory", "policy"][..], "policy"),
+		(&["search", "recursive"][..], "recursive"),
+		(&["search", "graph_context"][..], "graph_context"),
+		(&["security", "auth_keys"][..], "auth_keys"),
+	];
+
+	for (path, field) in cases {
+		let payload = remove_required_config_key(&sample_toml(true), path);
+		let config_path = write_temp_config(payload);
+		let result = elf_config::load(&config_path);
+
+		fs::remove_file(&config_path).expect("Failed to remove test config.");
+
+		assert_missing_field_error(result, field);
+	}
 }
 
 #[test]

--- a/packages/elf-config/tests/fixtures/sample_config.template.toml
+++ b/packages/elf-config/tests/fixtures/sample_config.template.toml
@@ -9,9 +9,10 @@ dsn            = "postgres://user:pass@127.0.0.1:5432/elf"
 pool_max_conns = 5
 
 [storage.qdrant]
-collection = "mem_notes_v2"
-url        = "http://127.0.0.1:6334"
-vector_dim = 4_096
+collection      = "mem_notes_v2"
+docs_collection = "doc_chunks_v1"
+url             = "http://127.0.0.1:6334"
+vector_dim      = 4_096
 
 [providers.embedding]
 api_base        = "http://localhost"
@@ -112,6 +113,11 @@ max_children_per_node = 4
 max_depth             = 2
 max_nodes_per_scope   = 32
 max_total_nodes       = 256
+
+[search.graph_context]
+enabled                     = false
+max_evidence_notes_per_fact = 16
+max_facts_per_item          = 16
 
 [ranking]
 recency_tau_days   = 60.0

--- a/packages/elf-domain/src/memory_policy.rs
+++ b/packages/elf-domain/src/memory_policy.rs
@@ -130,8 +130,8 @@ mod tests {
 		RankingBlend, RankingBlendSegment, RankingDeterministic, RankingDeterministicDecay,
 		RankingDeterministicHits, RankingDeterministicLexical, RankingDiversity,
 		RankingRetrievalSources, ReadProfiles, ScopePrecedence, ScopeWriteAllowed, Scopes, Search,
-		SearchCache, SearchDynamic, SearchExpansion, SearchExplain, SearchPrefilter, Security,
-		Service, Storage, TtlDays,
+		SearchCache, SearchDynamic, SearchExpansion, SearchExplain, SearchGraphContext,
+		SearchPrefilter, SearchRecursive, Security, Service, Storage, TtlDays,
 	};
 
 	fn test_config(policy: MemoryPolicy) -> Config {
@@ -310,8 +310,18 @@ mod tests {
 				candidate_retention_days: 2,
 				write_mode: "outbox".to_string(),
 			},
-			recursive: Default::default(),
-			graph_context: Default::default(),
+			recursive: SearchRecursive {
+				enabled: false,
+				max_depth: 2,
+				max_children_per_node: 4,
+				max_nodes_per_scope: 32,
+				max_total_nodes: 256,
+			},
+			graph_context: SearchGraphContext {
+				enabled: false,
+				max_facts_per_item: 16,
+				max_evidence_notes_per_fact: 16,
+			},
 		}
 	}
 

--- a/packages/elf-domain/src/writegate.rs
+++ b/packages/elf-domain/src/writegate.rs
@@ -303,8 +303,8 @@ mod tests {
 		RankingBlendSegment, RankingDeterministic, RankingDeterministicDecay,
 		RankingDeterministicHits, RankingDeterministicLexical, RankingDiversity,
 		RankingRetrievalSources, ReadProfiles, ScopePrecedence, ScopeWriteAllowed, Scopes, Search,
-		SearchCache, SearchDynamic, SearchExpansion, SearchExplain, SearchPrefilter, Security,
-		Service, Storage, TtlDays,
+		SearchCache, SearchDynamic, SearchExpansion, SearchExplain, SearchGraphContext,
+		SearchPrefilter, SearchRecursive, Security, Service, Storage, TtlDays,
 	};
 
 	fn test_ranking() -> Ranking {
@@ -403,7 +403,7 @@ mod tests {
 				update_sim_threshold: 0.8,
 				candidate_k: 10,
 				top_k: 5,
-				policy: MemoryPolicy::default(),
+				policy: MemoryPolicy { rules: vec![] },
 			},
 			search: Search {
 				expansion: SearchExpansion {
@@ -425,8 +425,18 @@ mod tests {
 					candidate_retention_days: 2,
 					write_mode: "outbox".to_string(),
 				},
-				recursive: Default::default(),
-				graph_context: Default::default(),
+				recursive: SearchRecursive {
+					enabled: false,
+					max_depth: 2,
+					max_children_per_node: 4,
+					max_nodes_per_scope: 32,
+					max_total_nodes: 256,
+				},
+				graph_context: SearchGraphContext {
+					enabled: false,
+					max_facts_per_item: 16,
+					max_evidence_notes_per_fact: 16,
+				},
 			},
 			ranking: test_ranking(),
 			lifecycle: Lifecycle {

--- a/packages/elf-domain/tests/domain.rs
+++ b/packages/elf-domain/tests/domain.rs
@@ -11,7 +11,8 @@ use elf_config::{
 	RankingDeterministic, RankingDeterministicDecay, RankingDeterministicHits,
 	RankingDeterministicLexical, RankingDiversity, RankingRetrievalSources, ReadProfiles,
 	ScopePrecedence, ScopeWriteAllowed, Scopes, Search, SearchCache, SearchDynamic,
-	SearchExpansion, SearchExplain, SearchPrefilter, Security, Service, Storage, TtlDays,
+	SearchExpansion, SearchExplain, SearchGraphContext, SearchPrefilter, SearchRecursive, Security,
+	Service, Storage, TtlDays,
 };
 use elf_domain::{evidence, ttl};
 
@@ -145,7 +146,7 @@ fn base_config() -> Config {
 			update_sim_threshold: 0.85,
 			candidate_k: 60,
 			top_k: 12,
-			policy: MemoryPolicy::default(),
+			policy: MemoryPolicy { rules: vec![] },
 		},
 		search: Search {
 			expansion: SearchExpansion {
@@ -167,8 +168,18 @@ fn base_config() -> Config {
 				candidate_retention_days: 2,
 				write_mode: "outbox".to_string(),
 			},
-			recursive: Default::default(),
-			graph_context: Default::default(),
+			recursive: SearchRecursive {
+				enabled: false,
+				max_depth: 2,
+				max_children_per_node: 4,
+				max_nodes_per_scope: 32,
+				max_total_nodes: 256,
+			},
+			graph_context: SearchGraphContext {
+				enabled: false,
+				max_facts_per_item: 16,
+				max_evidence_notes_per_fact: 16,
+			},
 		},
 		ranking: test_ranking(),
 		lifecycle: Lifecycle {

--- a/packages/elf-domain/tests/memory_policy.rs
+++ b/packages/elf-domain/tests/memory_policy.rs
@@ -10,7 +10,8 @@ use elf_config::{
 	RankingBlendSegment, RankingDeterministic, RankingDeterministicDecay, RankingDeterministicHits,
 	RankingDeterministicLexical, RankingDiversity, RankingRetrievalSources, ReadProfiles,
 	ScopePrecedence, ScopeWriteAllowed, Scopes, Search, SearchCache, SearchDynamic,
-	SearchExpansion, SearchExplain, SearchPrefilter, Security, Service, Storage, TtlDays,
+	SearchExpansion, SearchExplain, SearchGraphContext, SearchPrefilter, SearchRecursive, Security,
+	Service, Storage, TtlDays,
 };
 use elf_domain::memory_policy::{self, MemoryPolicyDecision, MemoryPolicyEvaluation};
 
@@ -186,8 +187,18 @@ fn memory_policy_search_config() -> Search {
 			candidate_retention_days: 2,
 			write_mode: "outbox".to_string(),
 		},
-		recursive: Default::default(),
-		graph_context: Default::default(),
+		recursive: SearchRecursive {
+			enabled: false,
+			max_depth: 2,
+			max_children_per_node: 4,
+			max_nodes_per_scope: 32,
+			max_total_nodes: 256,
+		},
+		graph_context: SearchGraphContext {
+			enabled: false,
+			max_facts_per_item: 16,
+			max_evidence_notes_per_fact: 16,
+		},
 	}
 }
 

--- a/packages/elf-service/tests/acceptance/chunk_search.rs
+++ b/packages/elf-service/tests/acceptance/chunk_search.rs
@@ -1044,12 +1044,10 @@ async fn search_details_payload_level_shapes_text_and_fields() {
 	};
 	let note_id = Uuid::new_v4();
 	let chunk_id = Uuid::new_v4();
-	let note_text = concat!(
-		"This is the long note body used for detail shaping. It contains enough tokens to show ",
-		"truncation and should be reduced for compact payload levels. The extra detail keeps ",
-		"running with repeated operational context about source references, structured fields, ",
-		"session hydration, ranking metadata, and payload contracts so l0 cannot equal the raw note.",
-	);
+	let max_note_chars = context.service.cfg.memory.max_note_chars as usize;
+	let note_text_seed =
+		"This is the long note body used for detail shaping and payload truncation. ";
+	let note_text = note_text_seed.repeat((max_note_chars / note_text_seed.len()) + 2);
 	let source_ref = serde_json::json!({
 		"schema": "note_source_ref/v1",
 		"locator": {
@@ -1060,12 +1058,13 @@ async fn search_details_payload_level_shapes_text_and_fields() {
 	});
 	let structured_summary = "Structured summary about payload levels and compact text behavior.";
 	let field_id = Uuid::new_v4();
-	let max_note_chars = context.service.cfg.memory.max_note_chars as usize;
+
+	assert!(note_text.len() > max_note_chars);
 
 	insert_note_with_importance_and_source_ref(
 		&context.service.db.pool,
 		note_id,
-		note_text,
+		note_text.as_str(),
 		&context.embedding_version,
 		0.8_f32,
 		1.0,
@@ -1081,12 +1080,20 @@ async fn search_details_payload_level_shapes_text_and_fields() {
 		0,
 		0,
 		note_text.len() as i32,
-		note_text,
+		note_text.as_str(),
 		&context.embedding_version,
 	)
 	.await;
-	upsert_point(&context.service, chunk_id, note_id, 0, 0, note_text.len() as i32, note_text)
-		.await;
+	upsert_point(
+		&context.service,
+		chunk_id,
+		note_id,
+		0,
+		0,
+		note_text.len() as i32,
+		note_text.as_str(),
+	)
+	.await;
 
 	let index = context
 		.service
@@ -1128,8 +1135,9 @@ async fn search_details_payload_level_shapes_text_and_fields() {
 	)
 	.await;
 
-	assert!(l0.text.len() <= max_note_chars);
-	assert!(l1.text.len() <= max_note_chars);
+	assert!(l0.text.chars().count() <= max_note_chars + 3);
+	assert!(l1.text.chars().count() <= max_note_chars + 3);
+	assert!(l0.text.ends_with("..."));
 	assert_eq!(l2.text, note_text);
 	assert_ne!(l0.text, l1.text);
 	assert_ne!(l0.text, note_text);

--- a/packages/elf-service/tests/acceptance/suite.rs
+++ b/packages/elf-service/tests/acceptance/suite.rs
@@ -35,12 +35,12 @@ use tokenizers::{Tokenizer, models::wordlevel::WordLevel};
 use tokio::time;
 
 use elf_config::{
-	Chunking, Config, EmbeddingProviderConfig, Lifecycle, LlmProviderConfig, Memory, Postgres,
-	ProviderConfig, Ranking, RankingBlend, RankingBlendSegment, RankingDeterministic,
+	Chunking, Config, EmbeddingProviderConfig, Lifecycle, LlmProviderConfig, Memory, MemoryPolicy,
+	Postgres, ProviderConfig, Ranking, RankingBlend, RankingBlendSegment, RankingDeterministic,
 	RankingDeterministicDecay, RankingDeterministicHits, RankingDeterministicLexical,
 	RankingDiversity, RankingRetrievalSources, ReadProfiles, ScopePrecedence, ScopeWriteAllowed,
-	Scopes, Search, SearchCache, SearchDynamic, SearchExpansion, SearchExplain, SearchPrefilter,
-	Security, Service, Storage, TtlDays,
+	Scopes, Search, SearchCache, SearchDynamic, SearchExpansion, SearchExplain, SearchGraphContext,
+	SearchPrefilter, SearchRecursive, Security, Service, Storage, TtlDays,
 };
 use elf_service::{
 	BoxFuture, ElfService, EmbeddingProvider, ExtractorProvider, RerankProvider, Result,
@@ -200,31 +200,9 @@ pub fn test_config(
 			update_sim_threshold: 0.85,
 			candidate_k: 60,
 			top_k: 12,
-			policy: Default::default(),
+			policy: MemoryPolicy { rules: vec![] },
 		},
-		search: Search {
-			expansion: SearchExpansion {
-				mode: "off".to_string(),
-				max_queries: 4,
-				include_original: true,
-			},
-			dynamic: SearchDynamic { min_candidates: 10, min_top_score: 0.12 },
-			prefilter: SearchPrefilter { max_candidates: 0 },
-			cache: SearchCache {
-				enabled: true,
-				expansion_ttl_days: 7,
-				rerank_ttl_days: 7,
-				max_payload_bytes: Some(262_144),
-			},
-			explain: SearchExplain {
-				retention_days: 7,
-				capture_candidates: false,
-				candidate_retention_days: 2,
-				write_mode: "outbox".to_string(),
-			},
-			recursive: Default::default(),
-			graph_context: Default::default(),
-		},
+		search: test_search(),
 		ranking: test_ranking(),
 		lifecycle: Lifecycle {
 			ttl_days: TtlDays {
@@ -328,6 +306,42 @@ fn test_tokenizer_repo(collection: &str) -> String {
 	tokenizer.save(&tokenizer_path, false).expect("Failed to save acceptance tokenizer.");
 
 	tokenizer_path.to_string_lossy().into_owned()
+}
+
+fn test_search() -> Search {
+	Search {
+		expansion: SearchExpansion {
+			mode: "off".to_string(),
+			max_queries: 4,
+			include_original: true,
+		},
+		dynamic: SearchDynamic { min_candidates: 10, min_top_score: 0.12 },
+		prefilter: SearchPrefilter { max_candidates: 0 },
+		cache: SearchCache {
+			enabled: true,
+			expansion_ttl_days: 7,
+			rerank_ttl_days: 7,
+			max_payload_bytes: Some(262_144),
+		},
+		explain: SearchExplain {
+			retention_days: 7,
+			capture_candidates: false,
+			candidate_retention_days: 2,
+			write_mode: "outbox".to_string(),
+		},
+		recursive: SearchRecursive {
+			enabled: false,
+			max_depth: 2,
+			max_children_per_node: 4,
+			max_nodes_per_scope: 32,
+			max_total_nodes: 256,
+		},
+		graph_context: SearchGraphContext {
+			enabled: false,
+			max_facts_per_item: 16,
+			max_evidence_notes_per_fact: 16,
+		},
+	}
 }
 
 fn test_ranking() -> Ranking {

--- a/packages/elf-service/tests/service.rs
+++ b/packages/elf-service/tests/service.rs
@@ -11,12 +11,13 @@ use serde_json::{Map, Value};
 use sqlx::PgPool;
 
 use elf_config::{
-	Chunking, Config, EmbeddingProviderConfig, Lifecycle, LlmProviderConfig, Memory, Postgres,
-	ProviderConfig, Qdrant, Ranking, RankingBlend, RankingBlendSegment, RankingDeterministic,
-	RankingDeterministicDecay, RankingDeterministicHits, RankingDeterministicLexical,
-	RankingDiversity, RankingRetrievalSources, ReadProfiles, ScopePrecedence, ScopeWriteAllowed,
-	Scopes, Search, SearchCache, SearchDynamic, SearchExpansion, SearchExplain, SearchPrefilter,
-	Security, Service, Storage, TtlDays,
+	Chunking, Config, EmbeddingProviderConfig, Lifecycle, LlmProviderConfig, Memory, MemoryPolicy,
+	Postgres, ProviderConfig, Qdrant, Ranking, RankingBlend, RankingBlendSegment,
+	RankingDeterministic, RankingDeterministicDecay, RankingDeterministicHits,
+	RankingDeterministicLexical, RankingDiversity, RankingRetrievalSources, ReadProfiles,
+	ScopePrecedence, ScopeWriteAllowed, Scopes, Search, SearchCache, SearchDynamic,
+	SearchExpansion, SearchExplain, SearchGraphContext, SearchPrefilter, SearchRecursive, Security,
+	Service, Storage, TtlDays,
 };
 use elf_service::{
 	AddNoteInput, AddNoteRequest, BoxFuture, ElfService, EmbeddingProvider, Error,
@@ -168,7 +169,7 @@ fn test_config() -> Config {
 			update_sim_threshold: 0.8,
 			candidate_k: 10,
 			top_k: 5,
-			policy: Default::default(),
+			policy: MemoryPolicy { rules: vec![] },
 		},
 		search: Search {
 			expansion: SearchExpansion {
@@ -190,8 +191,18 @@ fn test_config() -> Config {
 				candidate_retention_days: 2,
 				write_mode: "outbox".to_string(),
 			},
-			recursive: Default::default(),
-			graph_context: Default::default(),
+			recursive: SearchRecursive {
+				enabled: false,
+				max_depth: 2,
+				max_children_per_node: 4,
+				max_nodes_per_scope: 32,
+				max_total_nodes: 256,
+			},
+			graph_context: SearchGraphContext {
+				enabled: false,
+				max_facts_per_item: 16,
+				max_evidence_notes_per_fact: 16,
+			},
 		},
 		ranking: test_ranking(),
 		lifecycle: Lifecycle {

--- a/scripts/consolidation-harness.sh
+++ b/scripts/consolidation-harness.sh
@@ -145,9 +145,10 @@ dsn            = "${PG_DSN}"
 pool_max_conns = 10
 
 [storage.qdrant]
-collection = "${QDRANT_COLLECTION}"
-url        = "${QDRANT_GRPC_URL}"
-vector_dim = ${VECTOR_DIM_TOML}
+collection      = "${QDRANT_COLLECTION}"
+docs_collection = "${QDRANT_COLLECTION}_docs"
+url             = "${QDRANT_GRPC_URL}"
+vector_dim      = ${VECTOR_DIM_TOML}
 
 [providers.embedding]
 api_base    = "http://127.0.0.1"
@@ -207,6 +208,12 @@ max_notes_per_add_event = 3
 top_k                   = ${TOP_K}
 update_sim_threshold    = 0.85
 
+[memory.policy]
+
+[[memory.policy.rules]]
+min_confidence = 0.0
+min_importance = 0.0
+
 [chunking]
 enabled        = true
 max_tokens     = 512
@@ -235,6 +242,18 @@ retention_days = 7
 capture_candidates = false
 candidate_retention_days = 2
 write_mode = "outbox"
+
+[search.recursive]
+enabled               = false
+max_children_per_node = 4
+max_depth             = 2
+max_nodes_per_scope   = 32
+max_total_nodes       = 256
+
+[search.graph_context]
+enabled                     = false
+max_evidence_notes_per_fact = 16
+max_facts_per_item          = 16
 
 [ranking]
 recency_tau_days   = 60

--- a/scripts/context-misranking-harness.sh
+++ b/scripts/context-misranking-harness.sh
@@ -132,9 +132,10 @@ dsn            = "${PG_DSN}"
 pool_max_conns = 10
 
 [storage.qdrant]
-collection = "${QDRANT_COLLECTION}"
-url        = "${QDRANT_GRPC_URL}"
-vector_dim = ${VECTOR_DIM_TOML}
+collection      = "${QDRANT_COLLECTION}"
+docs_collection = "${QDRANT_COLLECTION}_docs"
+url             = "${QDRANT_GRPC_URL}"
+vector_dim      = ${VECTOR_DIM_TOML}
 
 [providers.embedding]
 api_base    = "http://127.0.0.1"
@@ -194,6 +195,12 @@ max_notes_per_add_event = 3
 top_k                   = 12
 update_sim_threshold    = 0.85
 
+[memory.policy]
+
+[[memory.policy.rules]]
+min_confidence = 0.0
+min_importance = 0.0
+
 [chunking]
 enabled        = true
 max_tokens     = 512
@@ -222,6 +229,18 @@ retention_days = 7
 capture_candidates = false
 candidate_retention_days = 2
 write_mode = "outbox"
+
+[search.recursive]
+enabled               = false
+max_children_per_node = 4
+max_depth             = 2
+max_nodes_per_scope   = 32
+max_total_nodes       = 256
+
+[search.graph_context]
+enabled                     = false
+max_evidence_notes_per_fact = 16
+max_facts_per_item          = 16
 
 [ranking]
 recency_tau_days   = 60

--- a/scripts/ranking-stability-harness.sh
+++ b/scripts/ranking-stability-harness.sh
@@ -121,9 +121,10 @@ dsn            = "${PG_DSN}"
 pool_max_conns = 10
 
 [storage.qdrant]
-collection = "${QDRANT_COLLECTION}"
-url        = "${QDRANT_GRPC_URL}"
-vector_dim = ${VECTOR_DIM_TOML}
+collection      = "${QDRANT_COLLECTION}"
+docs_collection = "${QDRANT_COLLECTION}_docs"
+url             = "${QDRANT_GRPC_URL}"
+vector_dim      = ${VECTOR_DIM_TOML}
 
 [providers.embedding]
 api_base    = "http://127.0.0.1"
@@ -183,6 +184,12 @@ max_notes_per_add_event = 3
 top_k                   = ${TOP_K}
 update_sim_threshold    = 0.85
 
+[memory.policy]
+
+[[memory.policy.rules]]
+min_confidence = 0.0
+min_importance = 0.0
+
 [chunking]
 enabled        = true
 max_tokens     = 512
@@ -211,6 +218,18 @@ retention_days = 2
 capture_candidates = false
 candidate_retention_days = 2
 write_mode = "outbox"
+
+[search.recursive]
+enabled               = false
+max_children_per_node = 4
+max_depth             = 2
+max_nodes_per_scope   = 32
+max_total_nodes       = 256
+
+[search.graph_context]
+enabled                     = false
+max_evidence_notes_per_fact = 16
+max_facts_per_item          = 16
 
 [ranking]
 recency_tau_days   = 0


### PR DESCRIPTION
## Summary
- Remove serde/Rust defaults for required ELF config fields so omitted TOML fails during config loading.
- Make examples, fixtures, harness-generated configs, and the spec template explicit for the required fields.
- Add loader coverage for missing required config fields and keep repo-native vstyle tasks runnable with the installed CLI.

## Verification
- cargo make fmt
- cargo make lint-fix
- cargo make checks
- semantic drift audit: pass for config spec versus loader behavior