### PR TITLE
XY-828: [ELF vNext P1] Implement reviewable consolidation worker and proposal review flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1127,6 +1127,7 @@ dependencies = [
  "elf-chunking",
  "elf-cli",
  "elf-config",
+ "elf-domain",
  "elf-providers",
  "elf-storage",
  "qdrant-client",

--- a/apps/elf-api/src/routes.rs
+++ b/apps/elf-api/src/routes.rs
@@ -16,7 +16,7 @@ use axum::{
 	routing,
 };
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::{Map, Value};
 use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 use utoipa::{OpenApi, ToSchema};
 use utoipa_scalar::{Scalar, Servable};
@@ -24,7 +24,14 @@ use uuid::Uuid;
 
 use crate::state::AppState;
 use elf_config::{SecurityAuthKey, SecurityAuthRole};
-use elf_domain::{english_gate, writegate::WritePolicy};
+use elf_domain::{
+	consolidation::{
+		ConsolidationInputRef, ConsolidationLineage, ConsolidationReviewAction,
+		ConsolidationReviewState,
+	},
+	english_gate,
+	writegate::WritePolicy,
+};
 use elf_service::{
 	AddEventRequest, AddEventResponse, AddNoteInput, AddNoteRequest, AddNoteResponse,
 	AdminGraphPredicateAliasAddRequest, AdminGraphPredicateAliasesListRequest,
@@ -34,15 +41,20 @@ use elf_service::{
 	AdminIngestionProfileDefaultResponse, AdminIngestionProfileDefaultSetRequest,
 	AdminIngestionProfileGetRequest, AdminIngestionProfileListRequest,
 	AdminIngestionProfileResponse, AdminIngestionProfileVersionsListRequest,
-	AdminIngestionProfileVersionsListResponse, AdminIngestionProfilesListResponse, DeleteRequest,
-	DeleteResponse, DocType, DocsExcerptResponse, DocsExcerptsGetRequest, DocsGetRequest,
-	DocsGetResponse, DocsPutRequest, DocsPutResponse, DocsSearchL0Request, DocsSearchL0Response,
-	Error, EventMessage, GranteeKind, GraphQueryEntityRef, GraphQueryPredicateRef,
-	GraphQueryRequest, GraphQueryResponse, IngestionProfileSelector, ListRequest, ListResponse,
-	NoteFetchRequest, NoteFetchResponse, NoteProvenanceBundleResponse, NoteProvenanceGetRequest,
-	PayloadLevel, PublishNoteRequest, QueryPlan, RankingRequestOverride, RebuildReport,
-	SearchDetailsRequest, SearchDetailsResult, SearchExplainRequest, SearchExplainResponse,
-	SearchIndexItem, SearchRequest, SearchResponse, SearchSessionGetRequest, SearchTimelineGroup,
+	AdminIngestionProfileVersionsListResponse, AdminIngestionProfilesListResponse,
+	ConsolidationProposalGetRequest, ConsolidationProposalInput, ConsolidationProposalResponse,
+	ConsolidationProposalReviewRequest, ConsolidationProposalsListRequest,
+	ConsolidationProposalsListResponse, ConsolidationRunCreateRequest,
+	ConsolidationRunCreateResponse, ConsolidationRunGetRequest, ConsolidationRunResponse,
+	ConsolidationRunsListRequest, ConsolidationRunsListResponse, DeleteRequest, DeleteResponse,
+	DocType, DocsExcerptResponse, DocsExcerptsGetRequest, DocsGetRequest, DocsGetResponse,
+	DocsPutRequest, DocsPutResponse, DocsSearchL0Request, DocsSearchL0Response, Error,
+	EventMessage, GranteeKind, GraphQueryEntityRef, GraphQueryPredicateRef, GraphQueryRequest,
+	GraphQueryResponse, IngestionProfileSelector, ListRequest, ListResponse, NoteFetchRequest,
+	NoteFetchResponse, NoteProvenanceBundleResponse, NoteProvenanceGetRequest, PayloadLevel,
+	PublishNoteRequest, QueryPlan, RankingRequestOverride, RebuildReport, SearchDetailsRequest,
+	SearchDetailsResult, SearchExplainRequest, SearchExplainResponse, SearchIndexItem,
+	SearchRequest, SearchResponse, SearchSessionGetRequest, SearchTimelineGroup,
 	SearchTimelineRequest, SearchTrajectoryResponse, SearchTrajectorySummary, ShareScope,
 	SpaceGrantRevokeRequest, SpaceGrantRevokeResponse, SpaceGrantUpsertRequest,
 	SpaceGrantsListRequest, TextPositionSelector, TextQuoteSelector, TraceBundleGetRequest,
@@ -115,6 +127,12 @@ const VIEWER_HTML: &str = include_str!("../static/viewer.html");
 		admin_ingestion_profile_versions_list,
 		admin_ingestion_profile_default_get,
 		admin_ingestion_profile_default_set,
+		consolidation_run_create,
+		consolidation_runs_list,
+		consolidation_run_get,
+		consolidation_proposals_list,
+		consolidation_proposal_get,
+		consolidation_proposal_review,
 		rebuild_qdrant,
 		searches_raw,
 		trace_recent_list,
@@ -140,6 +158,7 @@ const VIEWER_HTML: &str = include_str!("../static/viewer.html");
 		(name = "docs", description = "Document extension ingestion, search, and excerpt retrieval."),
 		(name = "search", description = "Progressive search sessions and raw search diagnostics."),
 		(name = "graph", description = "Graph query and predicate administration."),
+		(name = "consolidation", description = "Reviewable derived consolidation proposals."),
 		(name = "admin", description = "Local admin and operator inspection routes."),
 	)
 )]
@@ -312,6 +331,35 @@ struct AdminIngestionProfileGetQuery {
 struct AdminIngestionProfileDefaultSetBody {
 	profile_id: String,
 	version: Option<i32>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct ConsolidationRunCreateBody {
+	job_kind: String,
+	input_refs: Vec<ConsolidationInputRef>,
+	#[serde(default = "empty_json_object")]
+	source_snapshot: Value,
+	lineage: ConsolidationLineage,
+	#[serde(default)]
+	proposals: Vec<ConsolidationProposalInput>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct ConsolidationRunsListQuery {
+	limit: Option<u32>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct ConsolidationProposalsListQuery {
+	run_id: Option<Uuid>,
+	review_state: Option<ConsolidationReviewState>,
+	limit: Option<u32>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct ConsolidationProposalReviewBody {
+	action: ConsolidationReviewAction,
+	review_comment: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize, ToSchema)]
@@ -583,6 +631,20 @@ pub fn admin_router(state: AppState) -> Router {
 			"/v2/admin/events/ingestion-profiles",
 			routing::get(admin_ingestion_profiles_list).post(admin_ingestion_profile_create),
 		)
+		.route(
+			"/v2/admin/consolidation/runs",
+			routing::get(consolidation_runs_list).post(consolidation_run_create),
+		)
+		.route("/v2/admin/consolidation/runs/{run_id}", routing::get(consolidation_run_get))
+		.route("/v2/admin/consolidation/proposals", routing::get(consolidation_proposals_list))
+		.route(
+			"/v2/admin/consolidation/proposals/{proposal_id}",
+			routing::get(consolidation_proposal_get),
+		)
+		.route(
+			"/v2/admin/consolidation/proposals/{proposal_id}/review",
+			routing::post(consolidation_proposal_review),
+		)
 		.route("/v2/admin/qdrant/rebuild", routing::post(rebuild_qdrant))
 		.route("/v2/admin/searches/raw", routing::post(searches_raw))
 		.route("/v2/admin/traces/recent", routing::get(trace_recent_list))
@@ -618,6 +680,10 @@ where
 	Router::new()
 		.route(OPENAPI_JSON_PATH, routing::get(openapi_json))
 		.merge(Scalar::with_url(SCALAR_DOCS_PATH, <ApiDoc as OpenApi>::openapi()))
+}
+
+fn empty_json_object() -> Value {
+	Value::Object(Map::new())
 }
 
 fn json_error(
@@ -2364,6 +2430,241 @@ async fn admin_note_provenance_get(
 			tenant_id: ctx.tenant_id,
 			project_id: ctx.project_id,
 			note_id,
+		})
+		.await?;
+
+	Ok(Json(response))
+}
+
+#[utoipa::path(
+	post,
+	path = "/v2/admin/consolidation/runs",
+	tag = "consolidation",
+	request_body = Value,
+	responses(
+		(status = 200, description = "Consolidation run was created.", body = Value),
+		(status = 400, description = "Invalid request.", body = ErrorBody),
+		(status = 401, description = "Authentication required.", body = ErrorBody),
+		(status = 403, description = "Admin access required.", body = ErrorBody),
+		(status = 500, description = "Internal error.", body = ErrorBody),
+	)
+)]
+async fn consolidation_run_create(
+	State(state): State<AppState>,
+	headers: HeaderMap,
+	payload: Result<Json<ConsolidationRunCreateBody>, JsonRejection>,
+) -> Result<Json<ConsolidationRunCreateResponse>, ApiError> {
+	let ctx = RequestContext::from_headers(&headers)?;
+	let Json(payload) = payload.map_err(|err| {
+		tracing::warn!(error = %err, "Invalid request payload.");
+
+		json_error(StatusCode::BAD_REQUEST, "INVALID_REQUEST", "Invalid request payload.", None)
+	})?;
+	let response = state
+		.service
+		.consolidation_run_create(ConsolidationRunCreateRequest {
+			tenant_id: ctx.tenant_id,
+			project_id: ctx.project_id,
+			agent_id: ctx.agent_id,
+			job_kind: payload.job_kind,
+			input_refs: payload.input_refs,
+			source_snapshot: payload.source_snapshot,
+			lineage: payload.lineage,
+			proposals: payload.proposals,
+		})
+		.await?;
+
+	Ok(Json(response))
+}
+
+#[utoipa::path(
+	get,
+	path = "/v2/admin/consolidation/runs",
+	tag = "consolidation",
+	params(("limit" = Option<u32>, Query, description = "Maximum runs to return.")),
+	responses(
+		(status = 200, description = "Consolidation runs.", body = Value),
+		(status = 400, description = "Invalid request.", body = ErrorBody),
+		(status = 401, description = "Authentication required.", body = ErrorBody),
+		(status = 403, description = "Admin access required.", body = ErrorBody),
+		(status = 500, description = "Internal error.", body = ErrorBody),
+	)
+)]
+async fn consolidation_runs_list(
+	State(state): State<AppState>,
+	headers: HeaderMap,
+	query: Result<Query<ConsolidationRunsListQuery>, QueryRejection>,
+) -> Result<Json<ConsolidationRunsListResponse>, ApiError> {
+	let ctx = RequestContext::from_headers(&headers)?;
+	let Query(query) = query.map_err(|err| {
+		tracing::warn!(error = %err, "Invalid query parameters.");
+
+		json_error(
+			StatusCode::BAD_REQUEST,
+			"INVALID_REQUEST",
+			"Invalid query parameters.".to_string(),
+			None,
+		)
+	})?;
+	let response = state
+		.service
+		.consolidation_runs_list(ConsolidationRunsListRequest {
+			tenant_id: ctx.tenant_id,
+			project_id: ctx.project_id,
+			limit: query.limit,
+		})
+		.await?;
+
+	Ok(Json(response))
+}
+
+#[utoipa::path(
+	get,
+	path = "/v2/admin/consolidation/runs/{run_id}",
+	tag = "consolidation",
+	params(("run_id" = Uuid, Path, description = "Consolidation run ID.")),
+	responses(
+		(status = 200, description = "Consolidation run.", body = Value),
+		(status = 400, description = "Invalid request.", body = ErrorBody),
+		(status = 401, description = "Authentication required.", body = ErrorBody),
+		(status = 403, description = "Admin access required.", body = ErrorBody),
+		(status = 404, description = "Consolidation run was not found.", body = ErrorBody),
+		(status = 500, description = "Internal error.", body = ErrorBody),
+	)
+)]
+async fn consolidation_run_get(
+	State(state): State<AppState>,
+	headers: HeaderMap,
+	Path(run_id): Path<Uuid>,
+) -> Result<Json<ConsolidationRunResponse>, ApiError> {
+	let ctx = RequestContext::from_headers(&headers)?;
+	let response = state
+		.service
+		.consolidation_run_get(ConsolidationRunGetRequest {
+			tenant_id: ctx.tenant_id,
+			project_id: ctx.project_id,
+			run_id,
+		})
+		.await?;
+
+	Ok(Json(response))
+}
+
+#[utoipa::path(
+	get,
+	path = "/v2/admin/consolidation/proposals",
+	tag = "consolidation",
+	params(
+		("run_id" = Option<Uuid>, Query, description = "Optional run filter."),
+		("review_state" = Option<String>, Query, description = "Optional review-state filter."),
+		("limit" = Option<u32>, Query, description = "Maximum proposals to return."),
+	),
+	responses(
+		(status = 200, description = "Consolidation proposals.", body = Value),
+		(status = 400, description = "Invalid request.", body = ErrorBody),
+		(status = 401, description = "Authentication required.", body = ErrorBody),
+		(status = 403, description = "Admin access required.", body = ErrorBody),
+		(status = 500, description = "Internal error.", body = ErrorBody),
+	)
+)]
+async fn consolidation_proposals_list(
+	State(state): State<AppState>,
+	headers: HeaderMap,
+	query: Result<Query<ConsolidationProposalsListQuery>, QueryRejection>,
+) -> Result<Json<ConsolidationProposalsListResponse>, ApiError> {
+	let ctx = RequestContext::from_headers(&headers)?;
+	let Query(query) = query.map_err(|err| {
+		tracing::warn!(error = %err, "Invalid query parameters.");
+
+		json_error(
+			StatusCode::BAD_REQUEST,
+			"INVALID_REQUEST",
+			"Invalid query parameters.".to_string(),
+			None,
+		)
+	})?;
+	let response = state
+		.service
+		.consolidation_proposals_list(ConsolidationProposalsListRequest {
+			tenant_id: ctx.tenant_id,
+			project_id: ctx.project_id,
+			run_id: query.run_id,
+			review_state: query.review_state,
+			limit: query.limit,
+		})
+		.await?;
+
+	Ok(Json(response))
+}
+
+#[utoipa::path(
+	get,
+	path = "/v2/admin/consolidation/proposals/{proposal_id}",
+	tag = "consolidation",
+	params(("proposal_id" = Uuid, Path, description = "Consolidation proposal ID.")),
+	responses(
+		(status = 200, description = "Consolidation proposal.", body = Value),
+		(status = 400, description = "Invalid request.", body = ErrorBody),
+		(status = 401, description = "Authentication required.", body = ErrorBody),
+		(status = 403, description = "Admin access required.", body = ErrorBody),
+		(status = 404, description = "Consolidation proposal was not found.", body = ErrorBody),
+		(status = 500, description = "Internal error.", body = ErrorBody),
+	)
+)]
+async fn consolidation_proposal_get(
+	State(state): State<AppState>,
+	headers: HeaderMap,
+	Path(proposal_id): Path<Uuid>,
+) -> Result<Json<ConsolidationProposalResponse>, ApiError> {
+	let ctx = RequestContext::from_headers(&headers)?;
+	let response = state
+		.service
+		.consolidation_proposal_get(ConsolidationProposalGetRequest {
+			tenant_id: ctx.tenant_id,
+			project_id: ctx.project_id,
+			proposal_id,
+		})
+		.await?;
+
+	Ok(Json(response))
+}
+
+#[utoipa::path(
+	post,
+	path = "/v2/admin/consolidation/proposals/{proposal_id}/review",
+	tag = "consolidation",
+	params(("proposal_id" = Uuid, Path, description = "Consolidation proposal ID.")),
+	request_body = Value,
+	responses(
+		(status = 200, description = "Consolidation proposal review action was applied.", body = Value),
+		(status = 400, description = "Invalid request.", body = ErrorBody),
+		(status = 401, description = "Authentication required.", body = ErrorBody),
+		(status = 403, description = "Admin access required.", body = ErrorBody),
+		(status = 404, description = "Consolidation proposal was not found.", body = ErrorBody),
+		(status = 500, description = "Internal error.", body = ErrorBody),
+	)
+)]
+async fn consolidation_proposal_review(
+	State(state): State<AppState>,
+	headers: HeaderMap,
+	Path(proposal_id): Path<Uuid>,
+	payload: Result<Json<ConsolidationProposalReviewBody>, JsonRejection>,
+) -> Result<Json<ConsolidationProposalResponse>, ApiError> {
+	let ctx = RequestContext::from_headers(&headers)?;
+	let Json(payload) = payload.map_err(|err| {
+		tracing::warn!(error = %err, "Invalid request payload.");
+
+		json_error(StatusCode::BAD_REQUEST, "INVALID_REQUEST", "Invalid request payload.", None)
+	})?;
+	let response = state
+		.service
+		.consolidation_proposal_review(ConsolidationProposalReviewRequest {
+			tenant_id: ctx.tenant_id,
+			project_id: ctx.project_id,
+			reviewer_agent_id: ctx.agent_id,
+			proposal_id,
+			review_action: payload.action,
+			review_comment: payload.review_comment,
 		})
 		.await?;
 

--- a/apps/elf-api/tests/http.rs
+++ b/apps/elf-api/tests/http.rs
@@ -844,6 +844,12 @@ async fn openapi_json_route_serves_generated_contract() {
 	assert_openapi_method(&spec, "/v2/admin/searches/raw", "post");
 	assert_openapi_method(&spec, "/v2/admin/events/ingestion-profiles/default", "get");
 	assert_openapi_method(&spec, "/v2/admin/events/ingestion-profiles/default", "put");
+	assert_openapi_method(&spec, "/v2/admin/consolidation/runs", "post");
+	assert_openapi_method(&spec, "/v2/admin/consolidation/runs", "get");
+	assert_openapi_method(&spec, "/v2/admin/consolidation/runs/{run_id}", "get");
+	assert_openapi_method(&spec, "/v2/admin/consolidation/proposals", "get");
+	assert_openapi_method(&spec, "/v2/admin/consolidation/proposals/{proposal_id}", "get");
+	assert_openapi_method(&spec, "/v2/admin/consolidation/proposals/{proposal_id}/review", "post");
 }
 
 #[tokio::test]
@@ -868,6 +874,7 @@ async fn scalar_docs_route_serves_api_reference_html() {
 
 	assert!(html.contains("@scalar/api-reference"));
 	assert!(html.contains("/v2/admin/events/ingestion-profiles/default"));
+	assert!(html.contains("/v2/admin/consolidation/proposals"));
 }
 
 #[tokio::test]

--- a/apps/elf-eval/fixtures/real_world_memory/consolidation/contradiction_report_discard.json
+++ b/apps/elf-eval/fixtures/real_world_memory/consolidation/contradiction_report_discard.json
@@ -109,6 +109,13 @@
             "actual_review_action": "discard",
             "source_mutations": [],
             "unsupported_claim_count": 1,
+            "unsupported_claim_flags": [
+              {
+                "claim_id": "unsupported-applied-worker-claim",
+                "message": "The fixture has no evidence that a consolidation worker applied source note edits in production.",
+                "source_ref": "unsupported-applied-draft"
+              }
+            ],
             "diff": {
               "summary": "Reject a stale source-rewrite synthesis and preserve it as a contradiction report.",
               "before": {},
@@ -121,14 +128,6 @@
                 "contradiction": "Older source-rewrite draft conflicts with the current proposal-only consolidation rule."
               }
             }
-          }
-        ],
-        "executable_gaps": [
-          {
-            "primitive": "live_consolidation_worker_generation",
-            "follow_up_issue": "[ELF vNext P1] Implement reviewable consolidation worker and proposal review flow",
-            "reason": "This fixture scores checked-in proposal payloads; it does not execute scheduled LLM generation.",
-            "blocks_fixture_pass": false
           }
         ]
       }

--- a/apps/elf-eval/fixtures/real_world_memory/consolidation/preference_candidate_defer.json
+++ b/apps/elf-eval/fixtures/real_world_memory/consolidation/preference_candidate_defer.json
@@ -100,14 +100,6 @@
               }
             }
           }
-        ],
-        "executable_gaps": [
-          {
-            "primitive": "live_consolidation_worker_generation",
-            "follow_up_issue": "[ELF vNext P1] Implement reviewable consolidation worker and proposal review flow",
-            "reason": "This fixture scores checked-in proposal payloads; it does not execute scheduled LLM generation.",
-            "blocks_fixture_pass": false
-          }
         ]
       }
     }

--- a/apps/elf-eval/fixtures/real_world_memory/consolidation/project_summary_apply.json
+++ b/apps/elf-eval/fixtures/real_world_memory/consolidation/project_summary_apply.json
@@ -114,14 +114,6 @@
               }
             }
           }
-        ],
-        "executable_gaps": [
-          {
-            "primitive": "live_consolidation_worker_generation",
-            "follow_up_issue": "[ELF vNext P1] Implement reviewable consolidation worker and proposal review flow",
-            "reason": "This fixture scores checked-in proposal payloads; it does not execute scheduled LLM generation.",
-            "blocks_fixture_pass": false
-          }
         ]
       }
     }

--- a/apps/elf-eval/fixtures/real_world_memory/consolidation/weekly_decision_summary_apply.json
+++ b/apps/elf-eval/fixtures/real_world_memory/consolidation/weekly_decision_summary_apply.json
@@ -103,14 +103,6 @@
               }
             }
           }
-        ],
-        "executable_gaps": [
-          {
-            "primitive": "live_consolidation_worker_generation",
-            "follow_up_issue": "[ELF vNext P1] Implement reviewable consolidation worker and proposal review flow",
-            "reason": "This fixture scores checked-in proposal payloads; it does not execute scheduled LLM generation.",
-            "blocks_fixture_pass": false
-          }
         ]
       }
     }

--- a/apps/elf-eval/src/bin/real_world_job_benchmark.rs
+++ b/apps/elf-eval/src/bin/real_world_job_benchmark.rs
@@ -450,6 +450,8 @@ struct ConsolidationProposalFixture {
 	#[serde(default)]
 	unsupported_claim_count: usize,
 	#[serde(default)]
+	unsupported_claim_flags: Vec<Value>,
+	#[serde(default)]
 	diff: Value,
 }
 
@@ -1338,6 +1340,12 @@ fn validate_consolidation_proposal(
 	if !proposal.diff.is_null() && !proposal.diff.is_object() {
 		return Err(eyre::eyre!(
 			"{} consolidation proposal diff must be a JSON object when present.",
+			path.display()
+		));
+	}
+	if proposal.unsupported_claim_flags.iter().any(|flag| !flag.is_object()) {
+		return Err(eyre::eyre!(
+			"{} consolidation unsupported-claim flags must be JSON objects.",
 			path.display()
 		));
 	}
@@ -2700,7 +2708,9 @@ fn consolidation_proposal_report(
 		review_action_correct: proposal.expected_review_action == proposal.actual_review_action,
 		source_mutation_count: proposal.source_mutations.len()
 			+ forbidden_diff_key_count(&proposal.diff),
-		unsupported_claim_count: proposal.unsupported_claim_count,
+		unsupported_claim_count: proposal
+			.unsupported_claim_count
+			.max(proposal.unsupported_claim_flags.len()),
 	}
 }
 

--- a/apps/elf-eval/tests/real_world_job_benchmark.rs
+++ b/apps/elf-eval/tests/real_world_job_benchmark.rs
@@ -216,7 +216,7 @@ fn consolidation_fixtures_report_reviewable_proposal_metrics() -> Result<()> {
 	);
 	assert_eq!(
 		report.pointer("/summary/consolidation/executable_gap_count").and_then(Value::as_u64),
-		Some(4)
+		Some(0)
 	);
 	assert_eq!(
 		report.pointer("/summary/consolidation/lineage_completeness").and_then(Value::as_f64),
@@ -838,8 +838,10 @@ fn consolidation_report_renders_markdown_metrics_and_gaps() -> Result<()> {
 
 	assert!(markdown.contains("## Consolidation"));
 	assert!(markdown.contains("Source Mutations"));
-	assert!(markdown.contains("live_consolidation_worker_generation"));
-	assert!(markdown.contains("[ELF vNext P1] Implement reviewable consolidation worker"));
+	assert!(markdown.contains("Proposal Unsupported Claims"));
+	assert!(markdown.contains("Executable Gaps"));
+	assert!(markdown.contains("consolidation-contradiction-report-discard-001"));
+	assert!(!markdown.contains("live_consolidation_worker_generation"));
 
 	Ok(())
 }

--- a/apps/elf-worker/Cargo.toml
+++ b/apps/elf-worker/Cargo.toml
@@ -21,6 +21,7 @@ uuid               = { workspace = true }
 elf-chunking  = { workspace = true }
 elf-cli       = { workspace = true }
 elf-config    = { workspace = true }
+elf-domain    = { workspace = true }
 elf-providers = { workspace = true }
 elf-storage   = { workspace = true }
 

--- a/apps/elf-worker/src/worker.rs
+++ b/apps/elf-worker/src/worker.rs
@@ -17,11 +17,19 @@ use uuid::Uuid;
 use crate::{Error, Result};
 use elf_chunking::{Chunk, ChunkingConfig, Tokenizer};
 use elf_config::EmbeddingProviderConfig;
+use elf_domain::consolidation::{
+	CONSOLIDATION_CONTRACT_SCHEMA_V1, ConsolidationJobPayload, ConsolidationProposalContract,
+	ConsolidationReviewState, ConsolidationRunState, ConsolidationValidationError,
+};
 use elf_providers::embedding;
 use elf_storage::{
+	consolidation::{self, ConsolidationRunStateUpdate},
 	db::Db,
 	doc_outbox, docs,
-	models::{DocIndexingOutboxEntry, IndexingOutboxEntry, MemoryNote, TraceOutboxJob},
+	models::{
+		ConsolidationProposal, ConsolidationRunJob, DocIndexingOutboxEntry, IndexingOutboxEntry,
+		MemoryNote, TraceOutboxJob,
+	},
 	outbox,
 	qdrant::{BM25_MODEL, BM25_VECTOR_NAME, DENSE_VECTOR_NAME, QdrantStore},
 	queries,
@@ -35,6 +43,7 @@ const BASE_BACKOFF_MS: i64 = 500;
 const MAX_BACKOFF_MS: i64 = 30_000;
 const TRACE_CLEANUP_INTERVAL_SECONDS: i64 = 900;
 const TRACE_OUTBOX_LEASE_SECONDS: i64 = 30;
+const CONSOLIDATION_JOB_LEASE_SECONDS: i64 = 30;
 const MAX_OUTBOX_ERROR_CHARS: usize = 1_024;
 
 /// Shared runtime state used by the worker loop.
@@ -228,6 +237,9 @@ pub async fn run_worker(state: WorkerState) -> Result<()> {
 		if let Err(err) = process_trace_outbox_once(&state).await {
 			tracing::error!(error = %err, "Search trace outbox processing failed.");
 		}
+		if let Err(err) = process_consolidation_run_job_once(&state).await {
+			tracing::error!(error = %err, "Consolidation run job processing failed.");
+		}
 
 		let now = OffsetDateTime::now_utc();
 
@@ -257,6 +269,7 @@ pub async fn process_once(state: &WorkerState) -> Result<()> {
 	process_indexing_outbox_once(state).await?;
 	process_doc_indexing_outbox_once(state).await?;
 	process_trace_outbox_once(state).await?;
+	process_consolidation_run_job_once(state).await?;
 
 	Ok(())
 }
@@ -473,6 +486,54 @@ fn project_doc_ref_fields(
 	Ok((doc_ts, thread_id, domain, repo))
 }
 
+fn proposal_row_from_contract(
+	job: &ConsolidationRunJob,
+	now: OffsetDateTime,
+	proposal: ConsolidationProposalContract,
+) -> Result<ConsolidationProposal> {
+	proposal.validate().map_err(consolidation_validation_error)?;
+
+	Ok(ConsolidationProposal {
+		proposal_id: Uuid::new_v4(),
+		run_id: job.run_id,
+		tenant_id: job.tenant_id.clone(),
+		project_id: job.project_id.clone(),
+		agent_id: job.agent_id.clone(),
+		contract_schema: CONSOLIDATION_CONTRACT_SCHEMA_V1.to_string(),
+		proposal_kind: proposal.proposal_kind,
+		apply_intent: proposal.apply_intent.as_str().to_string(),
+		review_state: ConsolidationReviewState::Proposed.as_str().to_string(),
+		source_refs: encode_json(&proposal.source_refs, "consolidation source_refs")?,
+		source_snapshot: proposal.source_snapshot,
+		lineage: encode_json(&proposal.lineage, "consolidation lineage")?,
+		diff: encode_json(&proposal.diff, "consolidation diff")?,
+		confidence: proposal.confidence,
+		unsupported_claim_flags: encode_json(
+			&proposal.unsupported_claim_flags,
+			"consolidation unsupported_claim_flags",
+		)?,
+		contradiction_markers: encode_json(
+			&proposal.markers.contradictions,
+			"consolidation contradiction_markers",
+		)?,
+		staleness_markers: encode_json(
+			&proposal.markers.staleness,
+			"consolidation staleness_markers",
+		)?,
+		target_ref: proposal.target_ref,
+		proposed_payload: proposal.proposed_payload,
+		reviewer_agent_id: None,
+		review_comment: None,
+		reviewed_at: None,
+		created_at: now,
+		updated_at: now,
+	})
+}
+
+fn consolidation_validation_error(err: ConsolidationValidationError) -> Error {
+	Error::Validation(err.to_string())
+}
+
 async fn process_indexing_outbox_once(state: &WorkerState) -> Result<()> {
 	let now = OffsetDateTime::now_utc();
 	let job = outbox::claim_next_indexing_outbox_job(&state.db, now, CLAIM_LEASE_SECONDS).await?;
@@ -560,6 +621,34 @@ async fn process_trace_outbox_once(state: &WorkerState) -> Result<()> {
 			);
 
 			mark_trace_failed(&state.db, job.outbox_id, job.attempts, &err).await?;
+		},
+	}
+
+	Ok(())
+}
+
+async fn process_consolidation_run_job_once(state: &WorkerState) -> Result<()> {
+	let now = OffsetDateTime::now_utc();
+	let job = consolidation::claim_next_consolidation_run_job(
+		&state.db,
+		now,
+		CONSOLIDATION_JOB_LEASE_SECONDS,
+	)
+	.await?;
+	let Some(job) = job else { return Ok(()) };
+	let result = handle_consolidation_job(&state.db, &job).await;
+
+	match result {
+		Ok(()) => {},
+		Err(err) => {
+			tracing::error!(
+				error = %err,
+				job_id = %job.job_id,
+				run_id = %job.run_id,
+				"Consolidation run job failed."
+			);
+
+			mark_consolidation_failed(&state.db, job.job_id, job.attempts, &err).await?;
 		},
 	}
 
@@ -859,6 +948,92 @@ async fn handle_trace_job(db: &Db, job: &TraceOutboxJob) -> Result<()> {
 	insert_trace_items_tx(&mut *tx, trace_id, items).await?;
 	insert_trace_stages_tx(&mut tx, trace_id, stages).await?;
 	insert_trace_candidates_tx(&mut *tx, trace_id, candidates).await?;
+
+	tx.commit().await?;
+
+	Ok(())
+}
+
+async fn handle_consolidation_job(db: &Db, job: &ConsolidationRunJob) -> Result<()> {
+	let payload: ConsolidationJobPayload = serde_json::from_value(job.payload.clone())?;
+
+	payload.validate().map_err(consolidation_validation_error)?;
+
+	let existing = consolidation::get_consolidation_run(
+		&db.pool,
+		job.tenant_id.as_str(),
+		job.project_id.as_str(),
+		job.run_id,
+	)
+	.await?
+	.ok_or_else(|| Error::Validation("Consolidation run does not exist.".to_string()))?;
+	let current_state =
+		ConsolidationRunState::parse(existing.status.as_str()).ok_or_else(|| {
+			Error::Validation("Stored consolidation run status is invalid.".to_string())
+		})?;
+	let now = OffsetDateTime::now_utc();
+	let mut tx = db.pool.begin().await?;
+
+	match current_state {
+		ConsolidationRunState::Pending => {
+			current_state
+				.validate_transition(ConsolidationRunState::Running)
+				.map_err(consolidation_validation_error)?;
+
+			let empty_error = Value::Object(Default::default());
+
+			consolidation::update_consolidation_run_state(
+				&mut *tx,
+				ConsolidationRunStateUpdate {
+					tenant_id: job.tenant_id.as_str(),
+					project_id: job.project_id.as_str(),
+					run_id: job.run_id,
+					status: ConsolidationRunState::Running.as_str(),
+					error: &empty_error,
+					now,
+				},
+			)
+			.await?
+			.ok_or_else(|| Error::Validation("Consolidation run disappeared.".to_string()))?;
+		},
+		ConsolidationRunState::Running => {},
+		ConsolidationRunState::Completed
+		| ConsolidationRunState::Failed
+		| ConsolidationRunState::Cancelled => {
+			consolidation::mark_consolidation_run_job_done(&mut *tx, job.job_id, now).await?;
+
+			tx.commit().await?;
+
+			return Ok(());
+		},
+	}
+
+	for proposal in payload.proposals {
+		let row = proposal_row_from_contract(job, now, proposal)?;
+
+		consolidation::insert_consolidation_proposal(&mut *tx, &row).await?;
+	}
+
+	ConsolidationRunState::Running
+		.validate_transition(ConsolidationRunState::Completed)
+		.map_err(consolidation_validation_error)?;
+
+	let empty_error = Value::Object(Default::default());
+
+	consolidation::update_consolidation_run_state(
+		&mut *tx,
+		ConsolidationRunStateUpdate {
+			tenant_id: job.tenant_id.as_str(),
+			project_id: job.project_id.as_str(),
+			run_id: job.run_id,
+			status: ConsolidationRunState::Completed.as_str(),
+			error: &empty_error,
+			now,
+		},
+	)
+	.await?
+	.ok_or_else(|| Error::Validation("Consolidation run disappeared.".to_string()))?;
+	consolidation::mark_consolidation_run_job_done(&mut *tx, job.job_id, now).await?;
 
 	tx.commit().await?;
 
@@ -1431,6 +1606,31 @@ async fn mark_trace_failed(db: &Db, outbox_id: Uuid, attempts: i32, err: &Error)
 	outbox::mark_trace_outbox_failed(
 		db,
 		outbox_id,
+		next_attempts,
+		error_text.as_str(),
+		available_at,
+		now,
+	)
+	.await?;
+
+	Ok(())
+}
+
+async fn mark_consolidation_failed(
+	db: &Db,
+	job_id: Uuid,
+	attempts: i32,
+	err: &Error,
+) -> Result<()> {
+	let next_attempts = attempts.saturating_add(1);
+	let backoff = backoff_for_attempt(next_attempts);
+	let now = OffsetDateTime::now_utc();
+	let available_at = now + backoff;
+	let error_text = sanitize_outbox_error(&err.to_string());
+
+	consolidation::mark_consolidation_run_job_failed(
+		db,
+		job_id,
 		next_attempts,
 		error_text.as_str(),
 		available_at,

--- a/docs/guide/benchmarking/real_world_agent_memory_benchmark.md
+++ b/docs/guide/benchmarking/real_world_agent_memory_benchmark.md
@@ -241,9 +241,9 @@ proposal usefulness, lineage completeness, review action correctness, proposal
 unsupported-claim count, executable gap count, and source mutation count. Source
 mutation count must remain `0` for proposal-only cases.
 
-These fixtures encode proposal expectations only. They do not claim that a live
-scheduled consolidation worker generated the proposals; the report records that missing
-primitive as an executable gap with a follow-up issue title.
+These fixtures use the same reviewable proposal shape as the runtime manual/fixture
+consolidation service. They remain offline fixture responses and do not claim scheduled
+provider-backed proposal generation.
 
 Current checked-in knowledge-compilation increment:
 

--- a/docs/spec/real_world_agent_memory_benchmark_v1.md
+++ b/docs/spec/real_world_agent_memory_benchmark_v1.md
@@ -469,10 +469,10 @@ Consolidation suite reports MUST also include:
 - source mutation count.
 
 For proposal-only consolidation jobs, source mutation count MUST be `0`. If the runner
-cannot execute a live consolidation primitive, the report MUST include an executable
-gap with a precise follow-up issue or issue title. A proposal-only fixture MAY still
-pass when it verifies checked-in proposal payloads and the gap explicitly says that no
-live worker generation claim is being made.
+or adapter cannot execute the consolidation primitive it claims to evaluate, the report
+MUST include an executable gap with a precise follow-up issue or issue title. Offline
+fixtures MAY still pass when they verify checked-in proposal payloads and clearly avoid
+claiming scheduled provider-backed generation.
 
 ## Claim Rules
 

--- a/docs/spec/system_consolidation_proposals_v1.md
+++ b/docs/spec/system_consolidation_proposals_v1.md
@@ -117,6 +117,7 @@ Required fields:
 - `lineage`
 - `diff`
 - `confidence`
+- `unsupported_claim_flags`
 - `contradiction_markers`
 - `staleness_markers`
 - `target_ref`
@@ -131,6 +132,12 @@ Required fields:
 
 `lineage` must include non-empty `source_refs`. It may also include `parent_run_id`
 and `parent_proposal_ids`.
+
+`unsupported_claim_flags` is a reviewer prompt array. Each flag has:
+
+- `claim_id`: optional stable claim identifier
+- `message`: non-empty reviewer-facing text
+- `source`: optional source reference
 
 `contradiction_markers` and `staleness_markers` are review prompts. Each marker has:
 
@@ -186,6 +193,17 @@ Terminal states are `rejected`, `applied`, and `archived`.
 `applied` means the proposal has been approved and marked as applied to the derived
 target. It does not mean authoritative source memory was changed.
 
+Operator review actions map to the lifecycle states:
+
+- `approve`: `proposed -> approved`
+- `apply`: `approved -> applied`, or `proposed -> approved -> applied` with both
+  transitions audited
+- `discard`: `proposed|approved -> rejected`
+- `defer`: `proposed|approved -> archived`
+
+Every review transition must write an append-only audit event with proposal id, run id,
+reviewer agent id, action, prior state, next state, optional comment, and timestamp.
+
 ## Service Boundary
 
 The first implementation exposes fixture-driven service flows:
@@ -195,7 +213,8 @@ The first implementation exposes fixture-driven service flows:
 - get a consolidation run
 - list consolidation proposals
 - get a consolidation proposal
-- transition proposal review state
+- transition proposal review state through `approve`, `apply`, `discard`, and `defer`
+  actions with review-event readback
 
 These flows must not call LLM, embedding, rerank, or external provider adapters.
 

--- a/docs/spec/system_consolidation_proposals_v1.md
+++ b/docs/spec/system_consolidation_proposals_v1.md
@@ -97,6 +97,57 @@ Allowed run transitions:
 
 Terminal states are `completed`, `failed`, and `cancelled`.
 
+## Worker Job Contract
+
+Storage table: `consolidation_run_jobs`.
+
+The first runtime implementation is queue-backed and deterministic. Creating a
+fixture or manual consolidation run stores the immutable run input snapshot, enqueues
+one worker job, and returns the run plus `job_id`. The worker materializes queued
+proposal payloads into `consolidation_proposals`; API creation must not call LLM,
+embedding, rerank, or external provider adapters.
+
+Required fields:
+
+- `job_id`
+- `run_id`
+- `tenant_id`
+- `project_id`
+- `agent_id`
+- `job_kind`
+- `status`
+- `payload`
+- `attempts`
+- `last_error`
+- `available_at`
+- `created_at`
+- `updated_at`
+
+Job states:
+
+- `PENDING`
+- `CLAIMED`
+- `DONE`
+- `FAILED`
+
+`payload` is a JSON object with:
+
+- `contract_schema = "elf.consolidation/v1"`
+- `proposals`: array of proposal contracts matching this spec
+
+Worker rules:
+
+- Claim one due `PENDING`, expired `CLAIMED`, or retryable `FAILED` job with a lease.
+- Validate `payload.contract_schema` and every proposal before persistence.
+- Transition the run through `pending -> running -> completed` when materialization
+  succeeds.
+- Insert proposals with `review_state = proposed`.
+- Mark the job `DONE` in the same transaction as the proposal and run-state writes.
+- On failure, mark the job `FAILED`, increment attempts, preserve a bounded error, and
+  schedule retry.
+- Never mutate authoritative source notes, events, docs, traces, graph facts, or
+  search traces.
+
 ## Proposal Contract
 
 Storage table: `consolidation_proposals`.
@@ -208,7 +259,7 @@ reviewer agent id, action, prior state, next state, optional comment, and timest
 
 The first implementation exposes fixture-driven service flows:
 
-- create a consolidation run with optional proposal payloads
+- create a consolidation run with optional proposal payloads and queued worker `job_id`
 - list consolidation runs
 - get a consolidation run
 - list consolidation proposals

--- a/docs/spec/system_elf_memory_service_v2.md
+++ b/docs/spec/system_elf_memory_service_v2.md
@@ -980,6 +980,29 @@ Behavior:
 - These endpoints mirror the public note list/detail reads for local admin viewer use.
 - Note metadata that includes `created_at`, `hit_count`, and `last_hit_at` is available through `GET /v2/admin/notes/{note_id}/provenance`.
 
+Admin consolidation proposal review:
+- POST /v2/admin/consolidation/runs
+- GET /v2/admin/consolidation/runs
+- GET /v2/admin/consolidation/runs/{run_id}
+- GET /v2/admin/consolidation/proposals
+- GET /v2/admin/consolidation/proposals/{proposal_id}
+- POST /v2/admin/consolidation/proposals/{proposal_id}/review
+
+Behavior:
+- These endpoints expose fixture-driven or manually supplied consolidation runs and
+  reviewable derived proposals.
+- Proposal payloads must follow `elf.consolidation/v1`, carry source refs and
+  snapshots, and may include unsupported-claim flags, contradiction markers, and
+  staleness markers for reviewer inspection.
+- Review action values are `approve`, `apply`, `discard`, and `defer`.
+- `apply` records an approval transition before the applied transition when a proposal
+  starts from `proposed`.
+- Every review action writes append-only review audit events returned by proposal
+  detail readback.
+- These endpoints must not call LLM, embedding, rerank, or external provider adapters.
+- They must not mutate authoritative source notes, docs, events, traces, graph facts,
+  or search traces.
+
 POST /v2/admin/qdrant/rebuild
 
 Behavior:

--- a/docs/spec/system_elf_memory_service_v2.md
+++ b/docs/spec/system_elf_memory_service_v2.md
@@ -991,6 +991,9 @@ Admin consolidation proposal review:
 Behavior:
 - These endpoints expose fixture-driven or manually supplied consolidation runs and
   reviewable derived proposals.
+- Creating a consolidation run enqueues a deterministic `consolidation_run_jobs`
+  worker job and returns `job_id`; the worker materializes supplied proposal payloads
+  into `consolidation_proposals`.
 - Proposal payloads must follow `elf.consolidation/v1`, carry source refs and
   snapshots, and may include unsupported-claim flags, contradiction markers, and
   staleness markers for reviewer inspection.

--- a/packages/elf-domain/src/consolidation.rs
+++ b/packages/elf-domain/src/consolidation.rs
@@ -234,6 +234,40 @@ impl ConsolidationMarkers {
 	}
 }
 
+/// Unsupported-claim marker attached to a proposal for reviewer inspection.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct ConsolidationUnsupportedClaimFlag {
+	/// Stable claim identifier when the source fixture or worker supplies one.
+	pub claim_id: Option<String>,
+	/// Human-readable unsupported-claim description.
+	pub message: String,
+	/// Optional source that demonstrates why the claim is unsupported.
+	pub source: Option<ConsolidationInputRef>,
+}
+impl ConsolidationUnsupportedClaimFlag {
+	/// Validates unsupported-claim marker content and optional source evidence.
+	pub fn validate(&self) -> Result<(), ConsolidationValidationError> {
+		if self.message.trim().is_empty() {
+			return Err(ConsolidationValidationError::EmptyText {
+				field: "unsupported_claim_flags.message",
+			});
+		}
+
+		if let Some(claim_id) = &self.claim_id
+			&& claim_id.trim().is_empty()
+		{
+			return Err(ConsolidationValidationError::EmptyText {
+				field: "unsupported_claim_flags.claim_id",
+			});
+		}
+		if let Some(source) = &self.source {
+			source.validate()?;
+		}
+
+		Ok(())
+	}
+}
+
 /// Derived-output apply intent for a reviewable proposal.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -261,6 +295,31 @@ impl ConsolidationApplyIntent {
 			Self::UpdateDerivedKnowledgePage => "update_derived_knowledge_page",
 			Self::CreateDerivedGraphView => "create_derived_graph_view",
 			Self::NoOp => "no_op",
+		}
+	}
+}
+
+/// Reviewer action requested for a consolidation proposal.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConsolidationReviewAction {
+	/// Approve a proposal for later application.
+	Approve,
+	/// Apply an approved proposal to a derived target.
+	Apply,
+	/// Discard a proposal as rejected.
+	Discard,
+	/// Defer a proposal by archiving it for later audit.
+	Defer,
+}
+impl ConsolidationReviewAction {
+	/// Returns the canonical storage string.
+	pub fn as_str(self) -> &'static str {
+		match self {
+			Self::Approve => "approve",
+			Self::Apply => "apply",
+			Self::Discard => "discard",
+			Self::Defer => "defer",
 		}
 	}
 }
@@ -439,6 +498,9 @@ pub struct ConsolidationProposalContract {
 	pub lineage: ConsolidationLineage,
 	/// Model or fixture confidence in the proposal.
 	pub confidence: f32,
+	#[serde(default)]
+	/// Unsupported claims that the reviewer must inspect before accepting a proposal.
+	pub unsupported_claim_flags: Vec<ConsolidationUnsupportedClaimFlag>,
 	/// Review markers for contradiction and staleness checks.
 	pub markers: ConsolidationMarkers,
 	/// Reviewable derived-output diff.
@@ -467,6 +529,11 @@ impl ConsolidationProposalContract {
 		}
 
 		self.markers.validate()?;
+
+		for flag in &self.unsupported_claim_flags {
+			flag.validate()?;
+		}
+
 		self.diff.validate()?;
 
 		validate_json_object("target_ref", &self.target_ref)?;

--- a/packages/elf-domain/src/consolidation.rs
+++ b/packages/elf-domain/src/consolidation.rs
@@ -63,6 +63,8 @@ pub enum ConsolidationValidationError {
 		/// Name of the invalid field.
 		field: &'static str,
 	},
+	/// The queued contract schema did not match the consolidation v1 contract.
+	InvalidContractSchema,
 }
 impl Display for ConsolidationValidationError {
 	fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
@@ -79,6 +81,8 @@ impl Display for ConsolidationValidationError {
 			Self::InvalidRunTransition { from, to } =>
 				write!(f, "invalid consolidation run transition from {from:?} to {to:?}"),
 			Self::UnknownState { field } => write!(f, "{field} is not a known state"),
+			Self::InvalidContractSchema =>
+				write!(f, "contract_schema must be elf.consolidation/v1"),
 		}
 	}
 }
@@ -538,6 +542,30 @@ impl ConsolidationProposalContract {
 
 		validate_json_object("target_ref", &self.target_ref)?;
 		validate_json_object("proposed_payload", &self.proposed_payload)?;
+
+		Ok(())
+	}
+}
+
+/// Worker payload for materializing one consolidation run.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct ConsolidationJobPayload {
+	/// Versioned consolidation contract schema.
+	pub contract_schema: String,
+	#[serde(default)]
+	/// Proposals to persist for review.
+	pub proposals: Vec<ConsolidationProposalContract>,
+}
+impl ConsolidationJobPayload {
+	/// Validates the queued worker payload and all proposal contracts.
+	pub fn validate(&self) -> Result<(), ConsolidationValidationError> {
+		if self.contract_schema != CONSOLIDATION_CONTRACT_SCHEMA_V1 {
+			return Err(ConsolidationValidationError::InvalidContractSchema);
+		}
+
+		for proposal in &self.proposals {
+			proposal.validate()?;
+		}
 
 		Ok(())
 	}

--- a/packages/elf-domain/tests/consolidation.rs
+++ b/packages/elf-domain/tests/consolidation.rs
@@ -6,7 +6,8 @@ use time::OffsetDateTime;
 use uuid::Uuid;
 
 use elf_domain::consolidation::{
-	ConsolidationApplyIntent, ConsolidationInputRef, ConsolidationLineage, ConsolidationMarkers,
+	CONSOLIDATION_CONTRACT_SCHEMA_V1, ConsolidationApplyIntent, ConsolidationInputRef,
+	ConsolidationJobPayload, ConsolidationLineage, ConsolidationMarkers,
 	ConsolidationProposalContract, ConsolidationProposalDiff, ConsolidationReviewAction,
 	ConsolidationReviewState, ConsolidationRunState, ConsolidationSourceKind,
 	ConsolidationSourceSnapshot, ConsolidationUnsupportedClaimFlag, ConsolidationValidationError,
@@ -139,6 +140,21 @@ fn run_lifecycle_rejects_skipping_generation_state() {
 			.validate_transition(ConsolidationRunState::Completed)
 			.is_ok()
 	);
+}
+
+#[test]
+fn queued_payload_requires_consolidation_contract_schema() {
+	let source = source_ref();
+	let mut payload = ConsolidationJobPayload {
+		contract_schema: CONSOLIDATION_CONTRACT_SCHEMA_V1.to_string(),
+		proposals: vec![proposal_contract(source)],
+	};
+
+	assert!(payload.validate().is_ok());
+
+	payload.contract_schema = "elf.consolidation/v0".to_string();
+
+	assert_eq!(payload.validate(), Err(ConsolidationValidationError::InvalidContractSchema));
 }
 
 fn proposal_contract(source: ConsolidationInputRef) -> ConsolidationProposalContract {

--- a/packages/elf-domain/tests/consolidation.rs
+++ b/packages/elf-domain/tests/consolidation.rs
@@ -7,9 +7,9 @@ use uuid::Uuid;
 
 use elf_domain::consolidation::{
 	ConsolidationApplyIntent, ConsolidationInputRef, ConsolidationLineage, ConsolidationMarkers,
-	ConsolidationProposalContract, ConsolidationProposalDiff, ConsolidationReviewState,
-	ConsolidationRunState, ConsolidationSourceKind, ConsolidationSourceSnapshot,
-	ConsolidationValidationError,
+	ConsolidationProposalContract, ConsolidationProposalDiff, ConsolidationReviewAction,
+	ConsolidationReviewState, ConsolidationRunState, ConsolidationSourceKind,
+	ConsolidationSourceSnapshot, ConsolidationUnsupportedClaimFlag, ConsolidationValidationError,
 };
 
 #[test]
@@ -63,9 +63,39 @@ fn proposal_contract_rejects_destructive_diff_payloads() {
 }
 
 #[test]
+fn unsupported_claim_flags_require_reviewer_text() {
+	let source = source_ref();
+	let mut proposal = proposal_contract(source.clone());
+
+	proposal.unsupported_claim_flags = vec![ConsolidationUnsupportedClaimFlag {
+		claim_id: Some("unsupported-worker-claim".to_string()),
+		message: " ".to_string(),
+		source: Some(source),
+	}];
+
+	assert_eq!(
+		proposal.validate(),
+		Err(ConsolidationValidationError::EmptyText { field: "unsupported_claim_flags.message" })
+	);
+}
+
+#[test]
 fn destructive_apply_intents_are_not_part_of_the_contract() {
 	let parsed =
 		serde_json::from_value::<ConsolidationApplyIntent>(serde_json::json!("delete_source_note"));
+
+	assert!(parsed.is_err());
+}
+
+#[test]
+fn review_actions_use_explicit_operator_vocabulary() {
+	let action = serde_json::from_value::<ConsolidationReviewAction>(serde_json::json!("defer"))
+		.expect("review action should parse");
+
+	assert_eq!(action.as_str(), "defer");
+
+	let parsed =
+		serde_json::from_value::<ConsolidationReviewAction>(serde_json::json!("silently_apply"));
 
 	assert!(parsed.is_err());
 }
@@ -125,6 +155,7 @@ fn proposal_contract(source: ConsolidationInputRef) -> ConsolidationProposalCont
 		source_snapshot: serde_json::json!({ "window": "fixture" }),
 		lineage,
 		confidence: 0.85,
+		unsupported_claim_flags: Vec::new(),
 		markers: ConsolidationMarkers::default(),
 		diff: ConsolidationProposalDiff {
 			summary: "Create one derived note from stable evidence.".to_string(),

--- a/packages/elf-service/src/consolidation.rs
+++ b/packages/elf-service/src/consolidation.rs
@@ -8,14 +8,15 @@ use uuid::Uuid;
 use crate::{ElfService, Error, Result};
 use elf_domain::consolidation::{
 	self, CONSOLIDATION_CONTRACT_SCHEMA_V1, ConsolidationApplyIntent, ConsolidationInputRef,
-	ConsolidationLineage, ConsolidationMarkers, ConsolidationProposalContract,
-	ConsolidationProposalDiff, ConsolidationReviewAction, ConsolidationReviewState,
-	ConsolidationRunState, ConsolidationUnsupportedClaimFlag, ConsolidationValidationError,
+	ConsolidationJobPayload, ConsolidationLineage, ConsolidationMarkers,
+	ConsolidationProposalContract, ConsolidationProposalDiff, ConsolidationReviewAction,
+	ConsolidationReviewState, ConsolidationRunState, ConsolidationUnsupportedClaimFlag,
+	ConsolidationValidationError,
 };
 use elf_storage::{
 	consolidation::{
 		ConsolidationProposalReviewEventInsert, ConsolidationProposalReviewUpdate,
-		ConsolidationRunStateUpdate,
+		ConsolidationRunJobInsert,
 	},
 	models::{ConsolidationProposal, ConsolidationProposalReviewEvent, ConsolidationRun},
 };
@@ -32,7 +33,7 @@ pub struct ConsolidationRunCreateRequest {
 	pub project_id: String,
 	/// Agent registering the run.
 	pub agent_id: String,
-	/// Job kind, such as `fixture`, `manual`, or `scheduled`.
+	/// Job kind, such as `fixture` or `manual`.
 	pub job_kind: String,
 	/// Input references considered by the run.
 	pub input_refs: Vec<ConsolidationInputRef>,
@@ -78,22 +79,20 @@ pub struct ConsolidationProposalInput {
 	pub proposed_payload: Value,
 }
 impl ConsolidationProposalInput {
-	fn validate(&self) -> Result<()> {
-		let contract = ConsolidationProposalContract {
-			proposal_kind: self.proposal_kind.clone(),
+	fn into_contract(self) -> ConsolidationProposalContract {
+		ConsolidationProposalContract {
+			proposal_kind: self.proposal_kind,
 			apply_intent: self.apply_intent,
-			source_refs: self.source_refs.clone(),
-			source_snapshot: self.source_snapshot.clone(),
-			lineage: self.lineage.clone(),
+			source_refs: self.source_refs,
+			source_snapshot: self.source_snapshot,
+			lineage: self.lineage,
 			confidence: self.confidence,
-			unsupported_claim_flags: self.unsupported_claim_flags.clone(),
-			markers: self.markers.clone(),
-			diff: self.diff.clone(),
-			target_ref: self.target_ref.clone(),
-			proposed_payload: self.proposed_payload.clone(),
-		};
-
-		contract.validate().map_err(validation_error)
+			unsupported_claim_flags: self.unsupported_claim_flags,
+			markers: self.markers,
+			diff: self.diff,
+			target_ref: self.target_ref,
+			proposed_payload: self.proposed_payload,
+		}
 	}
 }
 
@@ -102,6 +101,8 @@ impl ConsolidationProposalInput {
 pub struct ConsolidationRunCreateResponse {
 	/// Created run.
 	pub run: ConsolidationRunResponse,
+	/// Enqueued worker job identifier.
+	pub job_id: Uuid,
 	/// Proposals stored with the run.
 	pub proposals: Vec<ConsolidationProposalResponse>,
 }
@@ -148,7 +149,7 @@ pub struct ConsolidationRunResponse {
 	pub agent_id: String,
 	/// Versioned consolidation contract schema.
 	pub contract_schema: String,
-	/// Job kind, such as fixture, manual, or scheduled.
+	/// Job kind, such as fixture or manual.
 	pub job_kind: String,
 	/// Current run state.
 	pub status: String,
@@ -383,25 +384,26 @@ impl ElfService {
 
 		req.lineage.validate().map_err(validation_error)?;
 
-		for proposal in &req.proposals {
-			proposal.validate()?;
-		}
-
-		let has_proposals = !req.proposals.is_empty();
-		let now = OffsetDateTime::now_utc();
-		let run_state = if has_proposals {
-			ConsolidationRunState::Running
-		} else {
-			ConsolidationRunState::Pending
+		let proposal_contracts =
+			req.proposals.into_iter().map(ConsolidationProposalInput::into_contract).collect();
+		let payload = ConsolidationJobPayload {
+			contract_schema: CONSOLIDATION_CONTRACT_SCHEMA_V1.to_string(),
+			proposals: proposal_contracts,
 		};
+
+		payload.validate().map_err(validation_error)?;
+
+		let now = OffsetDateTime::now_utc();
+		let run_state = ConsolidationRunState::Pending;
 		let run_id = Uuid::new_v4();
-		let mut run = ConsolidationRun {
+		let job_id = Uuid::new_v4();
+		let run = ConsolidationRun {
 			run_id,
 			tenant_id: req.tenant_id.clone(),
 			project_id: req.project_id.clone(),
 			agent_id: req.agent_id.clone(),
 			contract_schema: CONSOLIDATION_CONTRACT_SCHEMA_V1.to_string(),
-			job_kind: req.job_kind,
+			job_kind: req.job_kind.clone(),
 			status: run_state.as_str().to_string(),
 			input_refs: to_value(&req.input_refs)?,
 			source_snapshot: req.source_snapshot,
@@ -411,53 +413,32 @@ impl ElfService {
 			updated_at: now,
 			completed_at: terminal_time(run_state, now),
 		};
-		let mut proposals = Vec::with_capacity(req.proposals.len());
+		let payload_value = to_value(&payload)?;
 		let mut tx = self.db.pool.begin().await?;
 
 		elf_storage::consolidation::insert_consolidation_run(&mut *tx, &run).await?;
-
-		for input in req.proposals {
-			let proposal = proposal_row_from_input(
+		elf_storage::consolidation::insert_consolidation_run_job(
+			&mut *tx,
+			ConsolidationRunJobInsert {
+				job_id,
 				run_id,
-				req.tenant_id.as_str(),
-				req.project_id.as_str(),
-				req.agent_id.as_str(),
+				tenant_id: req.tenant_id.as_str(),
+				project_id: req.project_id.as_str(),
+				agent_id: req.agent_id.as_str(),
+				job_kind: req.job_kind.as_str(),
+				payload: &payload_value,
 				now,
-				input,
-			)?;
-
-			elf_storage::consolidation::insert_consolidation_proposal(&mut *tx, &proposal).await?;
-
-			proposals.push(ConsolidationProposalResponse::from(proposal));
-		}
-
-		if has_proposals {
-			run_state
-				.validate_transition(ConsolidationRunState::Completed)
-				.map_err(validation_error)?;
-
-			let terminal_error = empty_object();
-
-			run = elf_storage::consolidation::update_consolidation_run_state(
-				&mut *tx,
-				ConsolidationRunStateUpdate {
-					tenant_id: req.tenant_id.as_str(),
-					project_id: req.project_id.as_str(),
-					run_id,
-					status: ConsolidationRunState::Completed.as_str(),
-					error: &terminal_error,
-					now,
-				},
-			)
-			.await?
-			.ok_or_else(|| Error::NotFound {
-				message: "consolidation run not found".to_string(),
-			})?;
-		}
+			},
+		)
+		.await?;
 
 		tx.commit().await?;
 
-		Ok(ConsolidationRunCreateResponse { run: ConsolidationRunResponse::from(run), proposals })
+		Ok(ConsolidationRunCreateResponse {
+			run: ConsolidationRunResponse::from(run),
+			job_id,
+			proposals: Vec::new(),
+		})
 	}
 
 	/// Fetches one consolidation run.
@@ -654,42 +635,6 @@ impl ElfService {
 	}
 }
 
-fn proposal_row_from_input(
-	run_id: Uuid,
-	tenant_id: &str,
-	project_id: &str,
-	agent_id: &str,
-	now: OffsetDateTime,
-	input: ConsolidationProposalInput,
-) -> Result<ConsolidationProposal> {
-	Ok(ConsolidationProposal {
-		proposal_id: Uuid::new_v4(),
-		run_id,
-		tenant_id: tenant_id.to_string(),
-		project_id: project_id.to_string(),
-		agent_id: agent_id.to_string(),
-		contract_schema: CONSOLIDATION_CONTRACT_SCHEMA_V1.to_string(),
-		proposal_kind: input.proposal_kind,
-		apply_intent: input.apply_intent.as_str().to_string(),
-		review_state: ConsolidationReviewState::Proposed.as_str().to_string(),
-		source_refs: to_value(&input.source_refs)?,
-		source_snapshot: input.source_snapshot,
-		lineage: to_value(&input.lineage)?,
-		diff: to_value(&input.diff)?,
-		confidence: input.confidence,
-		unsupported_claim_flags: to_value(&input.unsupported_claim_flags)?,
-		contradiction_markers: to_value(&input.markers.contradictions)?,
-		staleness_markers: to_value(&input.markers.staleness)?,
-		target_ref: input.target_ref,
-		proposed_payload: input.proposed_payload,
-		reviewer_agent_id: None,
-		review_comment: None,
-		reviewed_at: None,
-		created_at: now,
-		updated_at: now,
-	})
-}
-
 fn validate_context(tenant_id: &str, project_id: &str, agent_id: &str) -> Result<()> {
 	validate_non_empty("tenant_id", tenant_id)?;
 	validate_non_empty("project_id", project_id)?;
@@ -698,7 +643,14 @@ fn validate_context(tenant_id: &str, project_id: &str, agent_id: &str) -> Result
 }
 
 fn validate_job_kind(job_kind: &str) -> Result<()> {
-	validate_non_empty("job_kind", job_kind)
+	validate_non_empty("job_kind", job_kind)?;
+
+	match job_kind {
+		"fixture" | "manual" => Ok(()),
+		_ => Err(Error::InvalidRequest {
+			message: "job_kind must be fixture or manual for consolidation v1.".to_string(),
+		}),
+	}
 }
 
 fn validate_non_empty(field: &'static str, value: &str) -> Result<()> {

--- a/packages/elf-service/src/consolidation.rs
+++ b/packages/elf-service/src/consolidation.rs
@@ -2,7 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
-use time::OffsetDateTime;
+use time::{Duration, OffsetDateTime};
 use uuid::Uuid;
 
 use crate::{ElfService, Error, Result};
@@ -578,8 +578,10 @@ impl ElfService {
 		let mut last_state = current;
 		let mut updated = existing;
 
-		for (action, next_state) in steps {
+		for (step_index, (action, next_state)) in steps.into_iter().enumerate() {
 			last_state.validate_transition(next_state).map_err(validation_error)?;
+
+			let transition_time = now.saturating_add(Duration::milliseconds(step_index as i64));
 
 			elf_storage::consolidation::insert_consolidation_proposal_review_event(
 				&mut *tx,
@@ -594,7 +596,7 @@ impl ElfService {
 					from_review_state: last_state.as_str(),
 					to_review_state: next_state.as_str(),
 					review_comment: req.review_comment.as_deref(),
-					created_at: now,
+					created_at: transition_time,
 				},
 			)
 			.await?;
@@ -608,7 +610,7 @@ impl ElfService {
 					review_state: next_state.as_str(),
 					reviewer_agent_id: req.reviewer_agent_id.as_str(),
 					review_comment: req.review_comment.as_deref(),
-					now,
+					now: transition_time,
 				},
 			)
 			.await?

--- a/packages/elf-service/src/consolidation.rs
+++ b/packages/elf-service/src/consolidation.rs
@@ -9,12 +9,15 @@ use crate::{ElfService, Error, Result};
 use elf_domain::consolidation::{
 	self, CONSOLIDATION_CONTRACT_SCHEMA_V1, ConsolidationApplyIntent, ConsolidationInputRef,
 	ConsolidationLineage, ConsolidationMarkers, ConsolidationProposalContract,
-	ConsolidationProposalDiff, ConsolidationReviewState, ConsolidationRunState,
-	ConsolidationValidationError,
+	ConsolidationProposalDiff, ConsolidationReviewAction, ConsolidationReviewState,
+	ConsolidationRunState, ConsolidationUnsupportedClaimFlag, ConsolidationValidationError,
 };
 use elf_storage::{
-	consolidation::{ConsolidationProposalReviewUpdate, ConsolidationRunStateUpdate},
-	models::{ConsolidationProposal, ConsolidationRun},
+	consolidation::{
+		ConsolidationProposalReviewEventInsert, ConsolidationProposalReviewUpdate,
+		ConsolidationRunStateUpdate,
+	},
+	models::{ConsolidationProposal, ConsolidationProposalReviewEvent, ConsolidationRun},
 };
 
 const DEFAULT_LIST_LIMIT: i64 = 50;
@@ -33,7 +36,7 @@ pub struct ConsolidationRunCreateRequest {
 	pub job_kind: String,
 	/// Input references considered by the run.
 	pub input_refs: Vec<ConsolidationInputRef>,
-	#[serde(default)]
+	#[serde(default = "empty_object")]
 	/// Aggregate source snapshot metadata for the run.
 	pub source_snapshot: Value,
 	/// Run lineage.
@@ -52,7 +55,7 @@ pub struct ConsolidationProposalInput {
 	pub apply_intent: ConsolidationApplyIntent,
 	/// Source references directly supporting the proposal.
 	pub source_refs: Vec<ConsolidationInputRef>,
-	#[serde(default)]
+	#[serde(default = "empty_object")]
 	/// Aggregate source snapshot metadata for reviewer inspection.
 	pub source_snapshot: Value,
 	/// Proposal lineage.
@@ -60,14 +63,17 @@ pub struct ConsolidationProposalInput {
 	/// Fixture confidence in the proposal.
 	pub confidence: f32,
 	#[serde(default)]
+	/// Unsupported claims reviewers must inspect before accepting the proposal.
+	pub unsupported_claim_flags: Vec<ConsolidationUnsupportedClaimFlag>,
+	#[serde(default)]
 	/// Review markers for contradiction and staleness checks.
 	pub markers: ConsolidationMarkers,
 	/// Reviewable derived-output diff.
 	pub diff: ConsolidationProposalDiff,
-	#[serde(default)]
+	#[serde(default = "empty_object")]
 	/// Derived target reference, when the target already exists.
 	pub target_ref: Value,
-	#[serde(default)]
+	#[serde(default = "empty_object")]
 	/// Proposed derived output payload.
 	pub proposed_payload: Value,
 }
@@ -80,6 +86,7 @@ impl ConsolidationProposalInput {
 			source_snapshot: self.source_snapshot.clone(),
 			lineage: self.lineage.clone(),
 			confidence: self.confidence,
+			unsupported_claim_flags: self.unsupported_claim_flags.clone(),
 			markers: self.markers.clone(),
 			diff: self.diff.clone(),
 			target_ref: self.target_ref.clone(),
@@ -214,21 +221,65 @@ pub struct ConsolidationProposalsListResponse {
 	pub proposals: Vec<ConsolidationProposalResponse>,
 }
 
-/// Request to transition a proposal review state.
+/// Request to apply one proposal review action.
 #[derive(Clone, Debug, Deserialize)]
 pub struct ConsolidationProposalReviewRequest {
 	/// Tenant that owns the proposal.
 	pub tenant_id: String,
 	/// Project that owns the proposal.
 	pub project_id: String,
-	/// Agent performing the review transition.
+	/// Agent performing the review action.
 	pub reviewer_agent_id: String,
 	/// Proposal identifier.
 	pub proposal_id: Uuid,
-	/// Requested review state.
-	pub review_state: ConsolidationReviewState,
+	/// Requested review action.
+	pub review_action: ConsolidationReviewAction,
 	/// Optional reviewer comment.
 	pub review_comment: Option<String>,
+}
+
+/// Public consolidation proposal review audit DTO.
+#[derive(Clone, Debug, Serialize)]
+pub struct ConsolidationProposalReviewEventResponse {
+	/// Review event identifier.
+	pub review_id: Uuid,
+	/// Reviewed proposal identifier.
+	pub proposal_id: Uuid,
+	/// Parent consolidation run identifier.
+	pub run_id: Uuid,
+	/// Tenant that owns the proposal.
+	pub tenant_id: String,
+	/// Project that owns the proposal.
+	pub project_id: String,
+	/// Agent that performed the review action.
+	pub reviewer_agent_id: String,
+	/// Review action requested by the reviewer.
+	pub action: String,
+	/// Review state before the transition.
+	pub from_review_state: String,
+	/// Review state after the transition.
+	pub to_review_state: String,
+	/// Optional reviewer comment.
+	pub review_comment: Option<String>,
+	/// Creation timestamp.
+	pub created_at: OffsetDateTime,
+}
+impl From<ConsolidationProposalReviewEvent> for ConsolidationProposalReviewEventResponse {
+	fn from(event: ConsolidationProposalReviewEvent) -> Self {
+		Self {
+			review_id: event.review_id,
+			proposal_id: event.proposal_id,
+			run_id: event.run_id,
+			tenant_id: event.tenant_id,
+			project_id: event.project_id,
+			reviewer_agent_id: event.reviewer_agent_id,
+			action: event.action,
+			from_review_state: event.from_review_state,
+			to_review_state: event.to_review_state,
+			review_comment: event.review_comment,
+			created_at: event.created_at,
+		}
+	}
 }
 
 /// Public consolidation proposal DTO.
@@ -262,6 +313,8 @@ pub struct ConsolidationProposalResponse {
 	pub diff: Value,
 	/// Proposal confidence score.
 	pub confidence: f32,
+	/// Serialized unsupported-claim flags.
+	pub unsupported_claim_flags: Value,
 	/// Serialized contradiction markers.
 	pub contradiction_markers: Value,
 	/// Serialized staleness markers.
@@ -280,6 +333,8 @@ pub struct ConsolidationProposalResponse {
 	pub created_at: OffsetDateTime,
 	/// Last update timestamp.
 	pub updated_at: OffsetDateTime,
+	/// Append-only review events for detail readback.
+	pub review_events: Vec<ConsolidationProposalReviewEventResponse>,
 }
 impl From<ConsolidationProposal> for ConsolidationProposalResponse {
 	fn from(proposal: ConsolidationProposal) -> Self {
@@ -298,6 +353,7 @@ impl From<ConsolidationProposal> for ConsolidationProposalResponse {
 			lineage: proposal.lineage,
 			diff: proposal.diff,
 			confidence: proposal.confidence,
+			unsupported_claim_flags: proposal.unsupported_claim_flags,
 			contradiction_markers: proposal.contradiction_markers,
 			staleness_markers: proposal.staleness_markers,
 			target_ref: proposal.target_ref,
@@ -307,6 +363,7 @@ impl From<ConsolidationProposal> for ConsolidationProposalResponse {
 			reviewed_at: proposal.reviewed_at,
 			created_at: proposal.created_at,
 			updated_at: proposal.updated_at,
+			review_events: Vec::new(),
 		}
 	}
 }
@@ -453,8 +510,18 @@ impl ElfService {
 		.ok_or_else(|| Error::NotFound {
 			message: "consolidation proposal not found".to_string(),
 		})?;
+		let review_events = self
+			.consolidation_proposal_review_events(
+				req.tenant_id.as_str(),
+				req.project_id.as_str(),
+				req.proposal_id,
+			)
+			.await?;
+		let mut response = ConsolidationProposalResponse::from(proposal);
 
-		Ok(ConsolidationProposalResponse::from(proposal))
+		response.review_events = review_events;
+
+		Ok(response)
 	}
 
 	/// Lists consolidation proposals.
@@ -478,7 +545,7 @@ impl ElfService {
 		Ok(ConsolidationProposalsListResponse { proposals })
 	}
 
-	/// Applies one allowed proposal review-state transition.
+	/// Applies one allowed proposal review action.
 	pub async fn consolidation_proposal_review(
 		&self,
 		req: ConsolidationProposalReviewRequest,
@@ -505,27 +572,83 @@ impl ElfService {
 					message: "stored proposal review_state is invalid".to_string(),
 				}
 			})?;
+		let now = OffsetDateTime::now_utc();
+		let steps = review_steps(current, req.review_action)?;
+		let mut tx = self.db.pool.begin().await?;
+		let mut last_state = current;
+		let mut updated = existing;
 
-		current.validate_transition(req.review_state).map_err(validation_error)?;
+		for (action, next_state) in steps {
+			last_state.validate_transition(next_state).map_err(validation_error)?;
 
-		let updated = elf_storage::consolidation::update_consolidation_proposal_review(
+			elf_storage::consolidation::insert_consolidation_proposal_review_event(
+				&mut *tx,
+				ConsolidationProposalReviewEventInsert {
+					review_id: Uuid::new_v4(),
+					proposal_id: req.proposal_id,
+					run_id: updated.run_id,
+					tenant_id: req.tenant_id.as_str(),
+					project_id: req.project_id.as_str(),
+					reviewer_agent_id: req.reviewer_agent_id.as_str(),
+					action: action.as_str(),
+					from_review_state: last_state.as_str(),
+					to_review_state: next_state.as_str(),
+					review_comment: req.review_comment.as_deref(),
+					created_at: now,
+				},
+			)
+			.await?;
+
+			updated = elf_storage::consolidation::update_consolidation_proposal_review(
+				&mut *tx,
+				ConsolidationProposalReviewUpdate {
+					tenant_id: req.tenant_id.as_str(),
+					project_id: req.project_id.as_str(),
+					proposal_id: req.proposal_id,
+					review_state: next_state.as_str(),
+					reviewer_agent_id: req.reviewer_agent_id.as_str(),
+					review_comment: req.review_comment.as_deref(),
+					now,
+				},
+			)
+			.await?
+			.ok_or_else(|| Error::NotFound {
+				message: "consolidation proposal not found".to_string(),
+			})?;
+			last_state = next_state;
+		}
+
+		tx.commit().await?;
+
+		let review_events = self
+			.consolidation_proposal_review_events(
+				req.tenant_id.as_str(),
+				req.project_id.as_str(),
+				req.proposal_id,
+			)
+			.await?;
+		let mut response = ConsolidationProposalResponse::from(updated);
+
+		response.review_events = review_events;
+
+		Ok(response)
+	}
+
+	async fn consolidation_proposal_review_events(
+		&self,
+		tenant_id: &str,
+		project_id: &str,
+		proposal_id: Uuid,
+	) -> Result<Vec<ConsolidationProposalReviewEventResponse>> {
+		let events = elf_storage::consolidation::list_consolidation_proposal_review_events(
 			&self.db.pool,
-			ConsolidationProposalReviewUpdate {
-				tenant_id: req.tenant_id.as_str(),
-				project_id: req.project_id.as_str(),
-				proposal_id: req.proposal_id,
-				review_state: req.review_state.as_str(),
-				reviewer_agent_id: req.reviewer_agent_id.as_str(),
-				review_comment: req.review_comment.as_deref(),
-				now: OffsetDateTime::now_utc(),
-			},
+			tenant_id,
+			project_id,
+			proposal_id,
 		)
-		.await?
-		.ok_or_else(|| Error::NotFound {
-			message: "consolidation proposal not found".to_string(),
-		})?;
+		.await?;
 
-		Ok(ConsolidationProposalResponse::from(updated))
+		Ok(events.into_iter().map(ConsolidationProposalReviewEventResponse::from).collect())
 	}
 }
 
@@ -552,6 +675,7 @@ fn proposal_row_from_input(
 		lineage: to_value(&input.lineage)?,
 		diff: to_value(&input.diff)?,
 		confidence: input.confidence,
+		unsupported_claim_flags: to_value(&input.unsupported_claim_flags)?,
 		contradiction_markers: to_value(&input.markers.contradictions)?,
 		staleness_markers: to_value(&input.markers.staleness)?,
 		target_ref: input.target_ref,
@@ -593,6 +717,41 @@ fn validate_object(field: &str, value: &Value) -> Result<()> {
 
 fn validation_error(err: ConsolidationValidationError) -> Error {
 	Error::InvalidRequest { message: err.to_string() }
+}
+
+fn review_steps(
+	current: ConsolidationReviewState,
+	action: ConsolidationReviewAction,
+) -> Result<Vec<(ConsolidationReviewAction, ConsolidationReviewState)>> {
+	let steps = match action {
+		ConsolidationReviewAction::Approve =>
+			vec![(ConsolidationReviewAction::Approve, ConsolidationReviewState::Approved)],
+		ConsolidationReviewAction::Apply => match current {
+			ConsolidationReviewState::Proposed => vec![
+				(ConsolidationReviewAction::Approve, ConsolidationReviewState::Approved),
+				(ConsolidationReviewAction::Apply, ConsolidationReviewState::Applied),
+			],
+			ConsolidationReviewState::Approved =>
+				vec![(ConsolidationReviewAction::Apply, ConsolidationReviewState::Applied)],
+			ConsolidationReviewState::Rejected
+			| ConsolidationReviewState::Applied
+			| ConsolidationReviewState::Archived =>
+				vec![(ConsolidationReviewAction::Apply, ConsolidationReviewState::Applied)],
+		},
+		ConsolidationReviewAction::Discard =>
+			vec![(ConsolidationReviewAction::Discard, ConsolidationReviewState::Rejected)],
+		ConsolidationReviewAction::Defer =>
+			vec![(ConsolidationReviewAction::Defer, ConsolidationReviewState::Archived)],
+	};
+	let mut state = current;
+
+	for (_, next_state) in &steps {
+		state.validate_transition(*next_state).map_err(validation_error)?;
+
+		state = *next_state;
+	}
+
+	Ok(steps)
 }
 
 fn bounded_limit(limit: Option<u32>) -> i64 {

--- a/packages/elf-service/src/lib.rs
+++ b/packages/elf-service/src/lib.rs
@@ -40,10 +40,10 @@ pub use self::{
 	},
 	consolidation::{
 		ConsolidationProposalGetRequest, ConsolidationProposalInput, ConsolidationProposalResponse,
-		ConsolidationProposalReviewRequest, ConsolidationProposalsListRequest,
-		ConsolidationProposalsListResponse, ConsolidationRunCreateRequest,
-		ConsolidationRunCreateResponse, ConsolidationRunGetRequest, ConsolidationRunResponse,
-		ConsolidationRunsListRequest, ConsolidationRunsListResponse,
+		ConsolidationProposalReviewEventResponse, ConsolidationProposalReviewRequest,
+		ConsolidationProposalsListRequest, ConsolidationProposalsListResponse,
+		ConsolidationRunCreateRequest, ConsolidationRunCreateResponse, ConsolidationRunGetRequest,
+		ConsolidationRunResponse, ConsolidationRunsListRequest, ConsolidationRunsListResponse,
 	},
 	delete::{DeleteRequest, DeleteResponse},
 	docs::{

--- a/packages/elf-service/tests/acceptance/consolidation.rs
+++ b/packages/elf-service/tests/acceptance/consolidation.rs
@@ -4,6 +4,7 @@ use time::OffsetDateTime;
 use uuid::Uuid;
 
 use crate::acceptance::{self, SpyExtractor, StubEmbedding, StubRerank};
+use elf_chunking::ChunkingConfig;
 use elf_domain::consolidation::{
 	ConsolidationApplyIntent, ConsolidationInputRef, ConsolidationLineage, ConsolidationMarker,
 	ConsolidationMarkerSeverity, ConsolidationMarkers, ConsolidationProposalDiff,
@@ -12,10 +13,13 @@ use elf_domain::consolidation::{
 };
 use elf_service::{
 	AddNoteInput, AddNoteRequest, ConsolidationProposalGetRequest, ConsolidationProposalInput,
-	ConsolidationProposalReviewRequest, ConsolidationRunCreateRequest,
-	ConsolidationRunCreateResponse, ElfService, Providers,
+	ConsolidationProposalReviewRequest, ConsolidationProposalsListRequest,
+	ConsolidationProposalsListResponse, ConsolidationRunCreateRequest,
+	ConsolidationRunCreateResponse, ConsolidationRunGetRequest, ElfService, Providers,
 };
+use elf_storage::{db::Db, qdrant::QdrantStore};
 use elf_testkit::TestDatabase;
+use elf_worker::worker::{self, WorkerState};
 
 const TENANT_ID: &str = "tenant_consolidation";
 const PROJECT_ID: &str = "project_consolidation";
@@ -86,6 +90,15 @@ fn proposal_input(source: &ConsolidationInputRef, kind: &str) -> ConsolidationPr
 			"text": "Fact: Consolidation proposals are derived and reviewable."
 		}),
 	}
+}
+
+fn proposal_id_by_kind(response: &ConsolidationProposalsListResponse, proposal_kind: &str) -> Uuid {
+	response
+		.proposals
+		.iter()
+		.find(|proposal| proposal.proposal_kind == proposal_kind)
+		.map(|proposal| proposal.proposal_id)
+		.expect("proposal kind should be present")
 }
 
 async fn setup_service(test_name: &str) -> Option<ConsolidationFixture> {
@@ -170,6 +183,49 @@ async fn create_run_with_proposals(
 		.expect("consolidation run should be created")
 }
 
+async fn process_consolidation_worker(service: &ElfService) {
+	let tokenizer = elf_chunking::load_tokenizer(&service.cfg.chunking.tokenizer_repo)
+		.expect("worker tokenizer should load");
+	let mut embedding = acceptance::dummy_embedding_provider();
+
+	embedding.dimensions = service.cfg.storage.qdrant.vector_dim;
+
+	let worker_state = WorkerState {
+		db: Db::connect(&service.cfg.storage.postgres).await.expect("Failed to connect worker DB."),
+		qdrant: QdrantStore::new(&service.cfg.storage.qdrant)
+			.expect("Failed to build Qdrant store."),
+		docs_qdrant: QdrantStore::new_with_collection(
+			&service.cfg.storage.qdrant,
+			&service.cfg.storage.qdrant.docs_collection,
+		)
+		.expect("Failed to build docs Qdrant store."),
+		embedding,
+		chunking: ChunkingConfig {
+			max_tokens: service.cfg.chunking.max_tokens,
+			overlap_tokens: service.cfg.chunking.overlap_tokens,
+		},
+		tokenizer,
+	};
+
+	worker::process_once(&worker_state).await.expect("consolidation worker should process once");
+}
+
+async fn materialized_proposals(
+	service: &ElfService,
+	run_id: Uuid,
+) -> ConsolidationProposalsListResponse {
+	service
+		.consolidation_proposals_list(ConsolidationProposalsListRequest {
+			tenant_id: TENANT_ID.to_string(),
+			project_id: PROJECT_ID.to_string(),
+			run_id: Some(run_id),
+			review_state: None,
+			limit: None,
+		})
+		.await
+		.expect("consolidation proposals should be listed")
+}
+
 #[tokio::test]
 #[ignore = "Requires external Postgres and Qdrant. Set ELF_PG_DSN and ELF_QDRANT_URL to run this test."]
 async fn apply_action_is_audited_without_source_rewrite() {
@@ -185,9 +241,32 @@ async fn apply_action_is_audited_without_source_rewrite() {
 	let created =
 		create_run_with_proposals(service, &source, vec![proposal_input(&source, "derived_note")])
 			.await;
-	let proposal = &created.proposals[0];
 
-	assert_eq!(created.run.status, "completed");
+	assert_eq!(created.run.status, "pending");
+	assert!(created.proposals.is_empty());
+
+	process_consolidation_worker(service).await;
+
+	let completed = service
+		.consolidation_run_get(ConsolidationRunGetRequest {
+			tenant_id: TENANT_ID.to_string(),
+			project_id: PROJECT_ID.to_string(),
+			run_id: created.run.run_id,
+		})
+		.await
+		.expect("consolidation run should remain readable");
+	let materialized = materialized_proposals(service, created.run.run_id).await;
+	let proposal = &materialized.proposals[0];
+	let job_status: String =
+		sqlx::query_scalar("SELECT status FROM consolidation_run_jobs WHERE job_id = $1")
+			.bind(created.job_id)
+			.fetch_one(&service.db.pool)
+			.await
+			.expect("consolidation job should be queryable");
+
+	assert_eq!(completed.status, "completed");
+	assert_eq!(job_status, "DONE");
+	assert_eq!(materialized.proposals.len(), 1);
 	assert_eq!(proposal.review_state, "proposed");
 	assert_eq!(proposal.unsupported_claim_flags.as_array().map(Vec::len), Some(1));
 	assert_eq!(proposal.contradiction_markers.as_array().map(Vec::len), Some(1));
@@ -253,8 +332,12 @@ async fn discard_and_defer_actions_remain_auditable() {
 		],
 	)
 	.await;
-	let discarded_id = created.proposals[0].proposal_id;
-	let deferred_id = created.proposals[1].proposal_id;
+
+	process_consolidation_worker(service).await;
+
+	let materialized = materialized_proposals(service, created.run.run_id).await;
+	let discarded_id = proposal_id_by_kind(&materialized, "contradiction_report");
+	let deferred_id = proposal_id_by_kind(&materialized, "preference_candidate");
 	let discarded = service
 		.consolidation_proposal_review(ConsolidationProposalReviewRequest {
 			tenant_id: TENANT_ID.to_string(),

--- a/packages/elf-service/tests/acceptance/consolidation.rs
+++ b/packages/elf-service/tests/acceptance/consolidation.rs
@@ -1,0 +1,297 @@
+use std::sync::{Arc, atomic::AtomicUsize};
+
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+use crate::acceptance::{self, SpyExtractor, StubEmbedding, StubRerank};
+use elf_domain::consolidation::{
+	ConsolidationApplyIntent, ConsolidationInputRef, ConsolidationLineage, ConsolidationMarker,
+	ConsolidationMarkerSeverity, ConsolidationMarkers, ConsolidationProposalDiff,
+	ConsolidationReviewAction, ConsolidationSourceKind, ConsolidationSourceSnapshot,
+	ConsolidationUnsupportedClaimFlag,
+};
+use elf_service::{
+	AddNoteInput, AddNoteRequest, ConsolidationProposalGetRequest, ConsolidationProposalInput,
+	ConsolidationProposalReviewRequest, ConsolidationRunCreateRequest,
+	ConsolidationRunCreateResponse, ElfService, Providers,
+};
+use elf_testkit::TestDatabase;
+
+const TENANT_ID: &str = "tenant_consolidation";
+const PROJECT_ID: &str = "project_consolidation";
+const AGENT_ID: &str = "agent_consolidation";
+
+struct ConsolidationFixture {
+	service: ElfService,
+	_test_db: TestDatabase,
+}
+
+fn source_ref(note_id: Uuid) -> ConsolidationInputRef {
+	ConsolidationInputRef {
+		kind: ConsolidationSourceKind::Note,
+		id: note_id,
+		snapshot: ConsolidationSourceSnapshot {
+			status: Some("active".to_string()),
+			updated_at: Some(OffsetDateTime::UNIX_EPOCH),
+			content_hash: Some("blake3:acceptance-source".to_string()),
+			embedding_version: Some("test:test:4096".to_string()),
+			trace_version: None,
+			source_ref: serde_json::json!({ "schema": "acceptance/v1" }),
+			metadata: serde_json::json!({ "fixture": "consolidation" }),
+		},
+	}
+}
+
+fn lineage(source: &ConsolidationInputRef) -> ConsolidationLineage {
+	ConsolidationLineage {
+		source_refs: vec![source.clone()],
+		parent_run_id: None,
+		parent_proposal_ids: Vec::new(),
+	}
+}
+
+fn proposal_input(source: &ConsolidationInputRef, kind: &str) -> ConsolidationProposalInput {
+	ConsolidationProposalInput {
+		proposal_kind: kind.to_string(),
+		apply_intent: ConsolidationApplyIntent::CreateDerivedNote,
+		source_refs: vec![source.clone()],
+		source_snapshot: serde_json::json!({ "source_count": 1 }),
+		lineage: lineage(source),
+		confidence: 0.82,
+		unsupported_claim_flags: vec![ConsolidationUnsupportedClaimFlag {
+			claim_id: Some("unsupported-claim".to_string()),
+			message: "The source does not prove that source notes may be rewritten.".to_string(),
+			source: Some(source.clone()),
+		}],
+		markers: ConsolidationMarkers {
+			contradictions: vec![ConsolidationMarker {
+				severity: ConsolidationMarkerSeverity::High,
+				message: "Stale rewrite evidence conflicts with the proposal-only rule."
+					.to_string(),
+				source: Some(source.clone()),
+			}],
+			staleness: Vec::new(),
+		},
+		diff: ConsolidationProposalDiff {
+			summary: "Create a reviewed derived note without changing source evidence.".to_string(),
+			before: serde_json::json!({}),
+			after: serde_json::json!({
+				"target": "derived_note",
+				"text": "Fact: Consolidation proposals are derived and reviewable."
+			}),
+		},
+		target_ref: serde_json::json!({}),
+		proposed_payload: serde_json::json!({
+			"type": "fact",
+			"text": "Fact: Consolidation proposals are derived and reviewable."
+		}),
+	}
+}
+
+async fn setup_service(test_name: &str) -> Option<ConsolidationFixture> {
+	let Some(test_db) = acceptance::test_db().await else {
+		eprintln!("Skipping {test_name}; set ELF_PG_DSN to run this test.");
+
+		return None;
+	};
+	let Some(qdrant_url) = acceptance::test_qdrant_url() else {
+		eprintln!("Skipping {test_name}; set ELF_QDRANT_URL to run this test.");
+
+		return None;
+	};
+	let collection = test_db.collection_name("elf_acceptance");
+	let docs_collection = test_db.collection_name("elf_acceptance_docs");
+	let cfg = acceptance::test_config(
+		test_db.dsn().to_string(),
+		qdrant_url,
+		4_096,
+		collection,
+		docs_collection,
+	);
+	let extractor = SpyExtractor {
+		calls: Arc::new(AtomicUsize::new(0)),
+		payload: serde_json::json!({ "notes": [] }),
+	};
+	let providers = Providers::new(
+		Arc::new(StubEmbedding { vector_dim: 4_096 }),
+		Arc::new(StubRerank),
+		Arc::new(extractor),
+	);
+	let service =
+		acceptance::build_service(cfg, providers).await.expect("Failed to build service.");
+
+	acceptance::reset_db(&service.db.pool).await.expect("Failed to reset test database.");
+
+	Some(ConsolidationFixture { service, _test_db: test_db })
+}
+
+async fn insert_source_note(service: &ElfService, key: &str, text: &str) -> Uuid {
+	let response = service
+		.add_note(AddNoteRequest {
+			tenant_id: TENANT_ID.to_string(),
+			project_id: PROJECT_ID.to_string(),
+			agent_id: AGENT_ID.to_string(),
+			scope: "agent_private".to_string(),
+			notes: vec![AddNoteInput {
+				r#type: "fact".to_string(),
+				key: Some(key.to_string()),
+				text: text.to_string(),
+				structured: None,
+				importance: 0.7,
+				confidence: 0.9,
+				ttl_days: None,
+				source_ref: serde_json::json!({ "schema": "acceptance/v1", "key": key }),
+				write_policy: None,
+			}],
+		})
+		.await
+		.expect("add_note should persist source note");
+
+	response.results[0].note_id.expect("source note id should be present")
+}
+
+async fn create_run_with_proposals(
+	service: &ElfService,
+	source: &ConsolidationInputRef,
+	proposals: Vec<ConsolidationProposalInput>,
+) -> ConsolidationRunCreateResponse {
+	service
+		.consolidation_run_create(ConsolidationRunCreateRequest {
+			tenant_id: TENANT_ID.to_string(),
+			project_id: PROJECT_ID.to_string(),
+			agent_id: AGENT_ID.to_string(),
+			job_kind: "manual".to_string(),
+			input_refs: vec![source.clone()],
+			source_snapshot: serde_json::json!({ "source_count": 1 }),
+			lineage: lineage(source),
+			proposals,
+		})
+		.await
+		.expect("consolidation run should be created")
+}
+
+#[tokio::test]
+#[ignore = "Requires external Postgres and Qdrant. Set ELF_PG_DSN and ELF_QDRANT_URL to run this test."]
+async fn apply_action_is_audited_without_source_rewrite() {
+	let Some(fixture) = setup_service("apply_action_is_audited_without_source_rewrite").await
+	else {
+		return;
+	};
+	let service = &fixture.service;
+	let source_text =
+		"Fact: Current consolidation output is derived and never rewrites source notes.";
+	let note_id = insert_source_note(service, "consolidation_source_rule", source_text).await;
+	let source = source_ref(note_id);
+	let created =
+		create_run_with_proposals(service, &source, vec![proposal_input(&source, "derived_note")])
+			.await;
+	let proposal = &created.proposals[0];
+
+	assert_eq!(created.run.status, "completed");
+	assert_eq!(proposal.review_state, "proposed");
+	assert_eq!(proposal.unsupported_claim_flags.as_array().map(Vec::len), Some(1));
+	assert_eq!(proposal.contradiction_markers.as_array().map(Vec::len), Some(1));
+
+	let reviewed = service
+		.consolidation_proposal_review(ConsolidationProposalReviewRequest {
+			tenant_id: TENANT_ID.to_string(),
+			project_id: PROJECT_ID.to_string(),
+			reviewer_agent_id: AGENT_ID.to_string(),
+			proposal_id: proposal.proposal_id,
+			review_action: ConsolidationReviewAction::Apply,
+			review_comment: Some("Apply reviewed derived proposal.".to_string()),
+		})
+		.await
+		.expect("review action should apply");
+
+	assert_eq!(reviewed.review_state, "applied");
+	assert_eq!(reviewed.review_events.len(), 2);
+	assert_eq!(reviewed.review_events[0].action, "approve");
+	assert_eq!(reviewed.review_events[0].from_review_state, "proposed");
+	assert_eq!(reviewed.review_events[0].to_review_state, "approved");
+	assert_eq!(reviewed.review_events[1].action, "apply");
+	assert_eq!(reviewed.review_events[1].from_review_state, "approved");
+	assert_eq!(reviewed.review_events[1].to_review_state, "applied");
+
+	let stored_text: String =
+		sqlx::query_scalar("SELECT text FROM memory_notes WHERE note_id = $1")
+			.bind(note_id)
+			.fetch_one(&service.db.pool)
+			.await
+			.expect("source note should still exist");
+	let version_count: i64 =
+		sqlx::query_scalar("SELECT count(*) FROM memory_note_versions WHERE note_id = $1")
+			.bind(note_id)
+			.fetch_one(&service.db.pool)
+			.await
+			.expect("source note versions should be queryable");
+
+	assert_eq!(stored_text, source_text);
+	assert_eq!(version_count, 1);
+}
+
+#[tokio::test]
+#[ignore = "Requires external Postgres and Qdrant. Set ELF_PG_DSN and ELF_QDRANT_URL to run this test."]
+async fn discard_and_defer_actions_remain_auditable() {
+	let Some(fixture) = setup_service("discard_and_defer_actions_remain_auditable").await else {
+		return;
+	};
+	let service = &fixture.service;
+	let note_id = insert_source_note(
+		service,
+		"consolidation_review_actions",
+		"Fact: Discarded and deferred proposals remain auditable.",
+	)
+	.await;
+	let source = source_ref(note_id);
+	let created = create_run_with_proposals(
+		service,
+		&source,
+		vec![
+			proposal_input(&source, "contradiction_report"),
+			proposal_input(&source, "preference_candidate"),
+		],
+	)
+	.await;
+	let discarded_id = created.proposals[0].proposal_id;
+	let deferred_id = created.proposals[1].proposal_id;
+	let discarded = service
+		.consolidation_proposal_review(ConsolidationProposalReviewRequest {
+			tenant_id: TENANT_ID.to_string(),
+			project_id: PROJECT_ID.to_string(),
+			reviewer_agent_id: AGENT_ID.to_string(),
+			proposal_id: discarded_id,
+			review_action: ConsolidationReviewAction::Discard,
+			review_comment: Some("Discard stale synthesis.".to_string()),
+		})
+		.await
+		.expect("discard should be allowed");
+	let deferred = service
+		.consolidation_proposal_review(ConsolidationProposalReviewRequest {
+			tenant_id: TENANT_ID.to_string(),
+			project_id: PROJECT_ID.to_string(),
+			reviewer_agent_id: AGENT_ID.to_string(),
+			proposal_id: deferred_id,
+			review_action: ConsolidationReviewAction::Defer,
+			review_comment: Some("Defer until more evidence is available.".to_string()),
+		})
+		.await
+		.expect("defer should be allowed");
+	let deferred_readback = service
+		.consolidation_proposal_get(ConsolidationProposalGetRequest {
+			tenant_id: TENANT_ID.to_string(),
+			project_id: PROJECT_ID.to_string(),
+			proposal_id: deferred_id,
+		})
+		.await
+		.expect("deferred proposal should remain readable");
+
+	assert_eq!(discarded.review_state, "rejected");
+	assert_eq!(discarded.review_events.len(), 1);
+	assert_eq!(discarded.review_events[0].action, "discard");
+	assert_eq!(deferred.review_state, "archived");
+	assert_eq!(deferred.review_events.len(), 1);
+	assert_eq!(deferred.review_events[0].action, "defer");
+	assert_eq!(deferred_readback.review_events.len(), 1);
+	assert_eq!(deferred_readback.review_events[0].to_review_state, "archived");
+}

--- a/packages/elf-service/tests/acceptance/suite.rs
+++ b/packages/elf-service/tests/acceptance/suite.rs
@@ -489,6 +489,7 @@ TRUNCATE
 	doc_chunk_embeddings,
 	doc_chunks,
 	doc_documents,
+	consolidation_run_jobs,
 	consolidation_proposal_reviews,
 	consolidation_proposals,
 	consolidation_runs,

--- a/packages/elf-service/tests/acceptance/suite.rs
+++ b/packages/elf-service/tests/acceptance/suite.rs
@@ -1,6 +1,7 @@
 mod add_note_no_llm;
 mod chunk_search;
 mod chunking;
+mod consolidation;
 mod docs_extension_v1;
 mod english_only_boundary;
 mod evidence_binding;
@@ -488,6 +489,9 @@ TRUNCATE
 	doc_chunk_embeddings,
 	doc_chunks,
 	doc_documents,
+	consolidation_proposal_reviews,
+	consolidation_proposals,
+	consolidation_runs,
 	memory_notes",
 	)
 	.execute(executor)

--- a/packages/elf-storage/src/consolidation.rs
+++ b/packages/elf-storage/src/consolidation.rs
@@ -7,7 +7,7 @@ use uuid::Uuid;
 
 use crate::{
 	Result,
-	models::{ConsolidationProposal, ConsolidationRun},
+	models::{ConsolidationProposal, ConsolidationProposalReviewEvent, ConsolidationRun},
 };
 
 const CONSOLIDATION_RUN_SELECT: &str = "\
@@ -45,6 +45,7 @@ SELECT
 	lineage,
 	diff,
 	confidence,
+	COALESCE(unsupported_claim_flags, '[]'::jsonb) AS unsupported_claim_flags,
 	COALESCE(contradiction_markers, '[]'::jsonb) AS contradiction_markers,
 	COALESCE(staleness_markers, '[]'::jsonb) AS staleness_markers,
 	COALESCE(target_ref, '{}'::jsonb) AS target_ref,
@@ -90,6 +91,32 @@ pub struct ConsolidationProposalReviewUpdate<'a> {
 	pub review_comment: Option<&'a str>,
 	/// Update timestamp.
 	pub now: OffsetDateTime,
+}
+
+/// Arguments for inserting a consolidation proposal review event.
+pub struct ConsolidationProposalReviewEventInsert<'a> {
+	/// Review event identifier.
+	pub review_id: Uuid,
+	/// Reviewed proposal identifier.
+	pub proposal_id: Uuid,
+	/// Parent consolidation run identifier.
+	pub run_id: Uuid,
+	/// Tenant that owns the proposal.
+	pub tenant_id: &'a str,
+	/// Project that owns the proposal.
+	pub project_id: &'a str,
+	/// Reviewing agent identifier.
+	pub reviewer_agent_id: &'a str,
+	/// Review action requested by the reviewer.
+	pub action: &'a str,
+	/// Review state before the transition.
+	pub from_review_state: &'a str,
+	/// Review state after the transition.
+	pub to_review_state: &'a str,
+	/// Optional reviewer comment.
+	pub review_comment: Option<&'a str>,
+	/// Creation timestamp.
+	pub created_at: OffsetDateTime,
 }
 
 /// Inserts one consolidation run.
@@ -271,6 +298,7 @@ INSERT INTO consolidation_proposals (
 	lineage,
 	diff,
 	confidence,
+	unsupported_claim_flags,
 	contradiction_markers,
 	staleness_markers,
 	target_ref,
@@ -281,7 +309,7 @@ INSERT INTO consolidation_proposals (
 	created_at,
 	updated_at
 )
-VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23)",
+VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24)",
 	)
 	.bind(proposal.proposal_id)
 	.bind(proposal.run_id)
@@ -297,6 +325,7 @@ VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$
 	.bind(&proposal.lineage)
 	.bind(&proposal.diff)
 	.bind(proposal.confidence)
+	.bind(&proposal.unsupported_claim_flags)
 	.bind(&proposal.contradiction_markers)
 	.bind(&proposal.staleness_markers)
 	.bind(&proposal.target_ref)
@@ -361,6 +390,7 @@ SELECT
 	lineage,
 	diff,
 	confidence,
+	COALESCE(unsupported_claim_flags, '[]'::jsonb) AS unsupported_claim_flags,
 	COALESCE(contradiction_markers, '[]'::jsonb) AS contradiction_markers,
 	COALESCE(staleness_markers, '[]'::jsonb) AS staleness_markers,
 	COALESCE(target_ref, '{}'::jsonb) AS target_ref,
@@ -422,6 +452,7 @@ RETURNING
 	lineage,
 	diff,
 	confidence,
+	COALESCE(unsupported_claim_flags, '[]'::jsonb) AS unsupported_claim_flags,
 	COALESCE(contradiction_markers, '[]'::jsonb) AS contradiction_markers,
 	COALESCE(staleness_markers, '[]'::jsonb) AS staleness_markers,
 	COALESCE(target_ref, '{}'::jsonb) AS target_ref,
@@ -443,4 +474,83 @@ RETURNING
 	.await?;
 
 	Ok(row)
+}
+
+/// Inserts one proposal review audit event.
+pub async fn insert_consolidation_proposal_review_event<'e, E>(
+	executor: E,
+	args: ConsolidationProposalReviewEventInsert<'_>,
+) -> Result<()>
+where
+	E: PgExecutor<'e>,
+{
+	sqlx::query(
+		"\
+INSERT INTO consolidation_proposal_reviews (
+	review_id,
+	proposal_id,
+	run_id,
+	tenant_id,
+	project_id,
+	reviewer_agent_id,
+	action,
+	from_review_state,
+	to_review_state,
+	review_comment,
+	created_at
+)
+VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)",
+	)
+	.bind(args.review_id)
+	.bind(args.proposal_id)
+	.bind(args.run_id)
+	.bind(args.tenant_id)
+	.bind(args.project_id)
+	.bind(args.reviewer_agent_id)
+	.bind(args.action)
+	.bind(args.from_review_state)
+	.bind(args.to_review_state)
+	.bind(args.review_comment)
+	.bind(args.created_at)
+	.execute(executor)
+	.await?;
+
+	Ok(())
+}
+
+/// Lists review events for one consolidation proposal.
+pub async fn list_consolidation_proposal_review_events<'e, E>(
+	executor: E,
+	tenant_id: &str,
+	project_id: &str,
+	proposal_id: Uuid,
+) -> Result<Vec<ConsolidationProposalReviewEvent>>
+where
+	E: PgExecutor<'e>,
+{
+	let rows = sqlx::query_as::<_, ConsolidationProposalReviewEvent>(
+		"\
+SELECT
+	review_id,
+	proposal_id,
+	run_id,
+	tenant_id,
+	project_id,
+	reviewer_agent_id,
+	action,
+	from_review_state,
+	to_review_state,
+	review_comment,
+	created_at
+FROM consolidation_proposal_reviews
+WHERE tenant_id = $1 AND project_id = $2 AND proposal_id = $3
+ORDER BY created_at ASC, review_id ASC",
+	)
+	.bind(tenant_id)
+	.bind(project_id)
+	.bind(proposal_id)
+	.fetch_all(executor)
+	.await?;
+
+	Ok(rows)
 }

--- a/packages/elf-storage/src/consolidation.rs
+++ b/packages/elf-storage/src/consolidation.rs
@@ -2,12 +2,16 @@
 
 use serde_json::Value;
 use sqlx::PgExecutor;
-use time::OffsetDateTime;
+use time::{Duration, OffsetDateTime};
 use uuid::Uuid;
 
 use crate::{
 	Result,
-	models::{ConsolidationProposal, ConsolidationProposalReviewEvent, ConsolidationRun},
+	db::Db,
+	models::{
+		ConsolidationProposal, ConsolidationProposalReviewEvent, ConsolidationRun,
+		ConsolidationRunJob,
+	},
 };
 
 const CONSOLIDATION_RUN_SELECT: &str = "\
@@ -119,6 +123,26 @@ pub struct ConsolidationProposalReviewEventInsert<'a> {
 	pub created_at: OffsetDateTime,
 }
 
+/// Arguments for inserting a consolidation worker job.
+pub struct ConsolidationRunJobInsert<'a> {
+	/// Worker job identifier.
+	pub job_id: Uuid,
+	/// Consolidation run to materialize.
+	pub run_id: Uuid,
+	/// Tenant that owns the run.
+	pub tenant_id: &'a str,
+	/// Project that owns the run.
+	pub project_id: &'a str,
+	/// Agent that registered the run.
+	pub agent_id: &'a str,
+	/// Job kind, such as fixture or manual.
+	pub job_kind: &'a str,
+	/// Queued proposal payload.
+	pub payload: &'a Value,
+	/// Creation timestamp.
+	pub now: OffsetDateTime,
+}
+
 /// Inserts one consolidation run.
 pub async fn insert_consolidation_run<'e, E>(executor: E, run: &ConsolidationRun) -> Result<()>
 where
@@ -158,6 +182,45 @@ VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)",
 	.bind(run.created_at)
 	.bind(run.updated_at)
 	.bind(run.completed_at)
+	.execute(executor)
+	.await?;
+
+	Ok(())
+}
+
+/// Enqueues one consolidation worker job.
+pub async fn insert_consolidation_run_job<'e, E>(
+	executor: E,
+	args: ConsolidationRunJobInsert<'_>,
+) -> Result<()>
+where
+	E: PgExecutor<'e>,
+{
+	sqlx::query(
+		"\
+INSERT INTO consolidation_run_jobs (
+	job_id,
+	run_id,
+	tenant_id,
+	project_id,
+	agent_id,
+	job_kind,
+	status,
+	payload,
+	available_at,
+	created_at,
+	updated_at
+)
+VALUES ($1,$2,$3,$4,$5,$6,'PENDING',$7,$8,$8,$8)",
+	)
+	.bind(args.job_id)
+	.bind(args.run_id)
+	.bind(args.tenant_id)
+	.bind(args.project_id)
+	.bind(args.agent_id)
+	.bind(args.job_kind)
+	.bind(args.payload)
+	.bind(args.now)
 	.execute(executor)
 	.await?;
 
@@ -223,6 +286,120 @@ LIMIT $3",
 	.await?;
 
 	Ok(rows)
+}
+
+/// Claims the next due consolidation worker job and leases it until `lease_seconds`.
+pub async fn claim_next_consolidation_run_job(
+	db: &Db,
+	now: OffsetDateTime,
+	lease_seconds: i64,
+) -> Result<Option<ConsolidationRunJob>> {
+	let mut tx = db.pool.begin().await?;
+	let row = sqlx::query_as::<_, ConsolidationRunJob>(
+		"\
+SELECT
+	job_id,
+	run_id,
+	tenant_id,
+	project_id,
+	agent_id,
+	job_kind,
+	status,
+	payload,
+	attempts,
+	last_error,
+	available_at,
+	created_at,
+	updated_at
+FROM consolidation_run_jobs
+WHERE status IN ('PENDING','FAILED','CLAIMED') AND available_at <= $1
+ORDER BY available_at ASC
+LIMIT 1
+FOR UPDATE SKIP LOCKED",
+	)
+	.bind(now)
+	.fetch_optional(&mut *tx)
+	.await?;
+	let job = if let Some(mut job) = row {
+		let lease_until = now + Duration::seconds(lease_seconds);
+
+		sqlx::query(
+			"\
+UPDATE consolidation_run_jobs
+SET status = 'CLAIMED', available_at = $1, updated_at = $2
+WHERE job_id = $3",
+		)
+		.bind(lease_until)
+		.bind(now)
+		.bind(job.job_id)
+		.execute(&mut *tx)
+		.await?;
+
+		job.status = "CLAIMED".to_string();
+		job.available_at = lease_until;
+		job.updated_at = now;
+
+		Some(job)
+	} else {
+		None
+	};
+
+	tx.commit().await?;
+
+	Ok(job)
+}
+
+/// Marks a consolidation worker job as completed.
+pub async fn mark_consolidation_run_job_done<'e, E>(
+	executor: E,
+	job_id: Uuid,
+	now: OffsetDateTime,
+) -> Result<()>
+where
+	E: PgExecutor<'e>,
+{
+	sqlx::query(
+		"\
+UPDATE consolidation_run_jobs
+SET status = 'DONE', updated_at = $1
+WHERE job_id = $2",
+	)
+	.bind(now)
+	.bind(job_id)
+	.execute(executor)
+	.await?;
+
+	Ok(())
+}
+
+/// Marks a consolidation worker job as failed and schedules its retry.
+pub async fn mark_consolidation_run_job_failed(
+	db: &Db,
+	job_id: Uuid,
+	attempts: i32,
+	error_text: &str,
+	available_at: OffsetDateTime,
+	now: OffsetDateTime,
+) -> Result<()> {
+	sqlx::query(
+		"\
+UPDATE consolidation_run_jobs
+SET status = 'FAILED',
+	attempts = $1,
+	last_error = $2,
+	available_at = $3,
+	updated_at = $4
+WHERE job_id = $5",
+	)
+	.bind(attempts)
+	.bind(error_text)
+	.bind(available_at)
+	.bind(now)
+	.bind(job_id)
+	.execute(&db.pool)
+	.await?;
+
+	Ok(())
 }
 
 /// Updates one consolidation run state.

--- a/packages/elf-storage/src/models.rs
+++ b/packages/elf-storage/src/models.rs
@@ -393,6 +393,37 @@ pub struct ConsolidationProposalReviewEvent {
 	pub created_at: OffsetDateTime,
 }
 
+/// Persisted consolidation worker job row.
+#[derive(Debug, FromRow)]
+pub struct ConsolidationRunJob {
+	/// Worker job identifier.
+	pub job_id: Uuid,
+	/// Consolidation run to materialize.
+	pub run_id: Uuid,
+	/// Tenant that owns the run.
+	pub tenant_id: String,
+	/// Project that owns the run.
+	pub project_id: String,
+	/// Agent that registered the run.
+	pub agent_id: String,
+	/// Job kind, such as fixture or manual.
+	pub job_kind: String,
+	/// Current job status.
+	pub status: String,
+	/// Queued proposal payload.
+	pub payload: Value,
+	/// Number of attempts already made.
+	pub attempts: i32,
+	/// Most recent failure text, if any.
+	pub last_error: Option<String>,
+	/// Earliest time the job may be claimed again.
+	pub available_at: OffsetDateTime,
+	/// Creation timestamp.
+	pub created_at: OffsetDateTime,
+	/// Last update timestamp.
+	pub updated_at: OffsetDateTime,
+}
+
 /// Persisted document row.
 #[derive(Debug, FromRow)]
 pub struct DocDocument {

--- a/packages/elf-storage/src/models.rs
+++ b/packages/elf-storage/src/models.rs
@@ -344,6 +344,8 @@ pub struct ConsolidationProposal {
 	pub diff: Value,
 	/// Proposal confidence score.
 	pub confidence: f32,
+	/// Serialized unsupported-claim flags.
+	pub unsupported_claim_flags: Value,
 	/// Serialized contradiction markers.
 	pub contradiction_markers: Value,
 	/// Serialized staleness markers.
@@ -362,6 +364,33 @@ pub struct ConsolidationProposal {
 	pub created_at: OffsetDateTime,
 	/// Last update timestamp.
 	pub updated_at: OffsetDateTime,
+}
+
+/// Persisted consolidation proposal review event row.
+#[derive(Debug, FromRow)]
+pub struct ConsolidationProposalReviewEvent {
+	/// Review event identifier.
+	pub review_id: Uuid,
+	/// Reviewed proposal identifier.
+	pub proposal_id: Uuid,
+	/// Parent consolidation run identifier.
+	pub run_id: Uuid,
+	/// Tenant that owns the proposal.
+	pub tenant_id: String,
+	/// Project that owns the proposal.
+	pub project_id: String,
+	/// Agent that performed the review action.
+	pub reviewer_agent_id: String,
+	/// Review action requested by the reviewer.
+	pub action: String,
+	/// Review state before the transition.
+	pub from_review_state: String,
+	/// Review state after the transition.
+	pub to_review_state: String,
+	/// Optional reviewer comment.
+	pub review_comment: Option<String>,
+	/// Creation timestamp.
+	pub created_at: OffsetDateTime,
 }
 
 /// Persisted document row.

--- a/packages/elf-storage/src/schema.rs
+++ b/packages/elf-storage/src/schema.rs
@@ -79,6 +79,9 @@ fn expand_includes(sql: &str) -> String {
 					out.push_str(include_str!("../../../sql/tables/031_consolidation_runs.sql")),
 				"tables/032_consolidation_proposals.sql" => out
 					.push_str(include_str!("../../../sql/tables/032_consolidation_proposals.sql")),
+				"tables/033_consolidation_proposal_reviews.sql" => out.push_str(include_str!(
+					"../../../sql/tables/033_consolidation_proposal_reviews.sql"
+				)),
 				"tables/023_memory_ingest_decisions.sql" => out
 					.push_str(include_str!("../../../sql/tables/023_memory_ingest_decisions.sql")),
 				"tables/024_memory_space_grants.sql" =>

--- a/packages/elf-storage/src/schema.rs
+++ b/packages/elf-storage/src/schema.rs
@@ -82,6 +82,8 @@ fn expand_includes(sql: &str) -> String {
 				"tables/033_consolidation_proposal_reviews.sql" => out.push_str(include_str!(
 					"../../../sql/tables/033_consolidation_proposal_reviews.sql"
 				)),
+				"tables/034_consolidation_run_jobs.sql" =>
+					out.push_str(include_str!("../../../sql/tables/034_consolidation_run_jobs.sql")),
 				"tables/023_memory_ingest_decisions.sql" => out
 					.push_str(include_str!("../../../sql/tables/023_memory_ingest_decisions.sql")),
 				"tables/024_memory_space_grants.sql" =>

--- a/packages/elf-storage/tests/db_smoke.rs
+++ b/packages/elf-storage/tests/db_smoke.rs
@@ -62,6 +62,15 @@ fn chunk_tables_exist_after_bootstrap() {
 		assert_eq!(count, 1);
 
 		let count: i64 = sqlx::query_scalar(
+			"SELECT count(*) FROM information_schema.tables WHERE table_name = 'consolidation_proposal_reviews'",
+		)
+		.fetch_one(&db.pool)
+		.await
+		.expect("Failed to query schema tables.");
+
+		assert_eq!(count, 1);
+
+		let count: i64 = sqlx::query_scalar(
 			"SELECT count(*) FROM information_schema.tables WHERE table_name = 'memory_space_grants'",
 		)
 		.fetch_one(&db.pool)

--- a/sql/init.sql
+++ b/sql/init.sql
@@ -32,3 +32,4 @@
 \ir tables/031_consolidation_runs.sql
 \ir tables/032_consolidation_proposals.sql
 \ir tables/033_consolidation_proposal_reviews.sql
+\ir tables/034_consolidation_run_jobs.sql

--- a/sql/init.sql
+++ b/sql/init.sql
@@ -31,3 +31,4 @@
 \ir tables/030_memory_ingestion_profile_defaults.sql
 \ir tables/031_consolidation_runs.sql
 \ir tables/032_consolidation_proposals.sql
+\ir tables/033_consolidation_proposal_reviews.sql

--- a/sql/tables/032_consolidation_proposals.sql
+++ b/sql/tables/032_consolidation_proposals.sql
@@ -13,6 +13,7 @@ CREATE TABLE IF NOT EXISTS consolidation_proposals (
 	lineage jsonb NOT NULL,
 	diff jsonb NOT NULL,
 	confidence real NOT NULL,
+	unsupported_claim_flags jsonb NOT NULL DEFAULT '[]'::jsonb,
 	contradiction_markers jsonb NOT NULL DEFAULT '[]'::jsonb,
 	staleness_markers jsonb NOT NULL DEFAULT '[]'::jsonb,
 	target_ref jsonb NOT NULL DEFAULT '{}'::jsonb,
@@ -74,6 +75,15 @@ ALTER TABLE consolidation_proposals
 ALTER TABLE consolidation_proposals
 	ADD CONSTRAINT ck_consolidation_proposals_confidence
 		CHECK (confidence >= 0.0 AND confidence <= 1.0);
+
+ALTER TABLE consolidation_proposals
+	ADD COLUMN IF NOT EXISTS unsupported_claim_flags jsonb NOT NULL DEFAULT '[]'::jsonb;
+
+ALTER TABLE consolidation_proposals
+	DROP CONSTRAINT IF EXISTS ck_consolidation_proposals_unsupported_claim_flags;
+ALTER TABLE consolidation_proposals
+	ADD CONSTRAINT ck_consolidation_proposals_unsupported_claim_flags
+		CHECK (jsonb_typeof(unsupported_claim_flags) = 'array');
 
 ALTER TABLE consolidation_proposals
 	DROP CONSTRAINT IF EXISTS ck_consolidation_proposals_contradiction_markers;

--- a/sql/tables/033_consolidation_proposal_reviews.sql
+++ b/sql/tables/033_consolidation_proposal_reviews.sql
@@ -1,0 +1,37 @@
+CREATE TABLE IF NOT EXISTS consolidation_proposal_reviews (
+	review_id uuid PRIMARY KEY,
+	proposal_id uuid NOT NULL REFERENCES consolidation_proposals(proposal_id) ON DELETE CASCADE,
+	run_id uuid NOT NULL REFERENCES consolidation_runs(run_id) ON DELETE CASCADE,
+	tenant_id text NOT NULL,
+	project_id text NOT NULL,
+	reviewer_agent_id text NOT NULL,
+	action text NOT NULL,
+	from_review_state text NOT NULL,
+	to_review_state text NOT NULL,
+	review_comment text NULL,
+	created_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE consolidation_proposal_reviews
+	DROP CONSTRAINT IF EXISTS ck_consolidation_proposal_reviews_action;
+ALTER TABLE consolidation_proposal_reviews
+	ADD CONSTRAINT ck_consolidation_proposal_reviews_action
+		CHECK (action IN ('approve', 'apply', 'discard', 'defer'));
+
+ALTER TABLE consolidation_proposal_reviews
+	DROP CONSTRAINT IF EXISTS ck_consolidation_proposal_reviews_from_state;
+ALTER TABLE consolidation_proposal_reviews
+	ADD CONSTRAINT ck_consolidation_proposal_reviews_from_state
+		CHECK (from_review_state IN ('proposed', 'approved', 'rejected', 'applied', 'archived'));
+
+ALTER TABLE consolidation_proposal_reviews
+	DROP CONSTRAINT IF EXISTS ck_consolidation_proposal_reviews_to_state;
+ALTER TABLE consolidation_proposal_reviews
+	ADD CONSTRAINT ck_consolidation_proposal_reviews_to_state
+		CHECK (to_review_state IN ('proposed', 'approved', 'rejected', 'applied', 'archived'));
+
+CREATE INDEX IF NOT EXISTS idx_consolidation_proposal_reviews_proposal_created
+	ON consolidation_proposal_reviews (proposal_id, created_at ASC, review_id ASC);
+
+CREATE INDEX IF NOT EXISTS idx_consolidation_proposal_reviews_context_created
+	ON consolidation_proposal_reviews (tenant_id, project_id, created_at DESC);

--- a/sql/tables/034_consolidation_run_jobs.sql
+++ b/sql/tables/034_consolidation_run_jobs.sql
@@ -1,0 +1,33 @@
+CREATE TABLE IF NOT EXISTS consolidation_run_jobs (
+	job_id uuid PRIMARY KEY,
+	run_id uuid NOT NULL REFERENCES consolidation_runs(run_id) ON DELETE CASCADE,
+	tenant_id text NOT NULL,
+	project_id text NOT NULL,
+	agent_id text NOT NULL,
+	job_kind text NOT NULL,
+	status text NOT NULL,
+	payload jsonb NOT NULL,
+	attempts int NOT NULL DEFAULT 0,
+	last_error text NULL,
+	available_at timestamptz NOT NULL DEFAULT now(),
+	created_at timestamptz NOT NULL DEFAULT now(),
+	updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE consolidation_run_jobs
+	DROP CONSTRAINT IF EXISTS ck_consolidation_run_jobs_status;
+ALTER TABLE consolidation_run_jobs
+	ADD CONSTRAINT ck_consolidation_run_jobs_status
+		CHECK (status IN ('PENDING', 'CLAIMED', 'DONE', 'FAILED'));
+
+ALTER TABLE consolidation_run_jobs
+	DROP CONSTRAINT IF EXISTS ck_consolidation_run_jobs_payload;
+ALTER TABLE consolidation_run_jobs
+	ADD CONSTRAINT ck_consolidation_run_jobs_payload
+		CHECK (jsonb_typeof(payload) = 'object');
+
+CREATE INDEX IF NOT EXISTS idx_consolidation_run_jobs_status_available
+	ON consolidation_run_jobs (status, available_at);
+
+CREATE INDEX IF NOT EXISTS idx_consolidation_run_jobs_run_status
+	ON consolidation_run_jobs (run_id, status);


### PR DESCRIPTION
## Summary
- Add a queue-backed consolidation run job table and worker materialization path.
- Keep run creation deterministic: API enqueues payloads, worker validates contracts and stores reviewable proposals.
- Preserve source immutability while supporting approve, apply, discard, and defer audit flows.

## Verification
- cargo make fmt
- cargo make lint-fix
- cargo make checks
- cargo make real-world-memory-consolidation
- cargo make real-world-memory
- git diff --check