### PR TITLE
Split core block SQL rows

### DIFF
--- a/packages/elf-service/src/core_blocks.rs
+++ b/packages/elf-service/src/core_blocks.rs
@@ -1,6 +1,7 @@
 //! Scoped core memory block APIs.
 
 mod persistence;
+mod rows;
 mod service;
 mod types;
 mod validation;

--- a/packages/elf-service/src/core_blocks/persistence/attachments.rs
+++ b/packages/elf-service/src/core_blocks/persistence/attachments.rs
@@ -5,8 +5,9 @@ use uuid::Uuid;
 use crate::{
 	Error, Result,
 	access::ORG_PROJECT_ID,
-	core_blocks::types::{
-		CoreBlockAttachmentRow, CoreBlockRow, PreparedAttachRequest, PreparedDetachRequest,
+	core_blocks::{
+		rows::{CoreBlockAttachmentRow, CoreBlockRow},
+		types::{PreparedAttachRequest, PreparedDetachRequest},
 	},
 };
 

--- a/packages/elf-service/src/core_blocks/persistence/audit.rs
+++ b/packages/elf-service/src/core_blocks/persistence/audit.rs
@@ -5,7 +5,10 @@ use uuid::Uuid;
 
 use crate::{
 	Result,
-	core_blocks::types::{CoreBlockAuditEvent, CoreBlockEventInput, CoreBlockEventRow},
+	core_blocks::{
+		rows::CoreBlockEventRow,
+		types::{CoreBlockAuditEvent, CoreBlockEventInput},
+	},
 };
 
 pub(in crate::core_blocks) async fn fetch_audit_history<'e, E>(

--- a/packages/elf-service/src/core_blocks/persistence/blocks.rs
+++ b/packages/elf-service/src/core_blocks/persistence/blocks.rs
@@ -5,10 +5,7 @@ use uuid::Uuid;
 
 use crate::{
 	Error, Result,
-	core_blocks::{
-		types::{CoreBlockRow, PreparedUpsertRequest},
-		validation,
-	},
+	core_blocks::{rows::CoreBlockRow, types::PreparedUpsertRequest, validation},
 };
 
 pub(in crate::core_blocks) async fn insert_core_block(

--- a/packages/elf-service/src/core_blocks/persistence/readback.rs
+++ b/packages/elf-service/src/core_blocks/persistence/readback.rs
@@ -1,6 +1,6 @@
 use sqlx::PgExecutor;
 
-use crate::{Result, core_blocks::types::CoreBlockJoinedRow};
+use crate::{Result, core_blocks::rows::CoreBlockJoinedRow};
 
 pub(in crate::core_blocks) async fn fetch_attached_block_rows<'e, E>(
 	executor: E,

--- a/packages/elf-service/src/core_blocks/rows.rs
+++ b/packages/elf-service/src/core_blocks/rows.rs
@@ -1,0 +1,117 @@
+use std::collections::HashMap;
+
+use serde_json::Value;
+use sqlx::FromRow;
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+use crate::core_blocks::types::{CoreBlockAuditEvent, CoreBlockItem, CoreBlockRecord};
+
+#[derive(Clone, Debug, FromRow)]
+pub(in crate::core_blocks) struct CoreBlockRow {
+	pub(in crate::core_blocks) block_id: Uuid,
+	pub(in crate::core_blocks) tenant_id: String,
+	pub(in crate::core_blocks) project_id: String,
+	pub(in crate::core_blocks) agent_id: String,
+	pub(in crate::core_blocks) scope: String,
+	pub(in crate::core_blocks) key: String,
+	pub(in crate::core_blocks) title: String,
+	pub(in crate::core_blocks) content: String,
+	pub(in crate::core_blocks) source_ref: Value,
+	pub(in crate::core_blocks) status: String,
+	pub(in crate::core_blocks) created_at: OffsetDateTime,
+	pub(in crate::core_blocks) updated_at: OffsetDateTime,
+}
+impl CoreBlockRow {
+	pub(in crate::core_blocks) fn into_record(self) -> CoreBlockRecord {
+		CoreBlockRecord {
+			block_id: self.block_id,
+			tenant_id: self.tenant_id,
+			project_id: self.project_id,
+			agent_id: self.agent_id,
+			scope: self.scope,
+			key: self.key,
+			title: self.title,
+			content: self.content,
+			source_ref: self.source_ref,
+			status: self.status,
+			created_at: self.created_at,
+			updated_at: self.updated_at,
+		}
+	}
+}
+
+#[derive(Clone, Debug, FromRow)]
+pub(in crate::core_blocks) struct CoreBlockAttachmentRow {
+	pub(in crate::core_blocks) attachment_id: Uuid,
+	pub(in crate::core_blocks) block_id: Uuid,
+	pub(in crate::core_blocks) tenant_id: String,
+	pub(in crate::core_blocks) project_id: String,
+	pub(in crate::core_blocks) agent_id: String,
+	pub(in crate::core_blocks) read_profile: String,
+	pub(in crate::core_blocks) attached_by_agent_id: String,
+	pub(in crate::core_blocks) attached_at: OffsetDateTime,
+	pub(in crate::core_blocks) detached_by_agent_id: Option<String>,
+	pub(in crate::core_blocks) detached_at: Option<OffsetDateTime>,
+}
+
+#[derive(Clone, Debug, FromRow)]
+pub(in crate::core_blocks) struct CoreBlockJoinedRow {
+	pub(in crate::core_blocks) attachment_id: Uuid,
+	pub(in crate::core_blocks) attachment_agent_id: String,
+	pub(in crate::core_blocks) attached_by_agent_id: String,
+	pub(in crate::core_blocks) attached_at: OffsetDateTime,
+	pub(in crate::core_blocks) block_id: Uuid,
+	pub(in crate::core_blocks) tenant_id: String,
+	pub(in crate::core_blocks) project_id: String,
+	pub(in crate::core_blocks) agent_id: String,
+	pub(in crate::core_blocks) scope: String,
+	pub(in crate::core_blocks) key: String,
+	pub(in crate::core_blocks) title: String,
+	pub(in crate::core_blocks) content: String,
+	pub(in crate::core_blocks) source_ref: Value,
+	pub(in crate::core_blocks) status: String,
+	pub(in crate::core_blocks) created_at: OffsetDateTime,
+	pub(in crate::core_blocks) updated_at: OffsetDateTime,
+}
+impl CoreBlockJoinedRow {
+	pub(in crate::core_blocks) fn into_item(
+		self,
+		audit_by_block: &HashMap<Uuid, Vec<CoreBlockAuditEvent>>,
+	) -> CoreBlockItem {
+		let audit_history = audit_by_block.get(&self.block_id).cloned().unwrap_or_else(Vec::new);
+
+		CoreBlockItem {
+			block_id: self.block_id,
+			attachment_id: self.attachment_id,
+			tenant_id: self.tenant_id,
+			project_id: self.project_id,
+			agent_id: self.agent_id,
+			scope: self.scope,
+			key: self.key,
+			title: self.title,
+			content: self.content,
+			source_ref: self.source_ref,
+			status: self.status,
+			updated_at: self.updated_at,
+			attached_at: self.attached_at,
+			attached_by_agent_id: self.attached_by_agent_id,
+			audit_history,
+		}
+	}
+}
+
+#[derive(Clone, Debug, FromRow)]
+pub(in crate::core_blocks) struct CoreBlockEventRow {
+	pub(in crate::core_blocks) event_id: Uuid,
+	pub(in crate::core_blocks) block_id: Uuid,
+	pub(in crate::core_blocks) attachment_id: Option<Uuid>,
+	pub(in crate::core_blocks) actor_agent_id: String,
+	pub(in crate::core_blocks) event_type: String,
+	pub(in crate::core_blocks) target_agent_id: Option<String>,
+	pub(in crate::core_blocks) read_profile: Option<String>,
+	pub(in crate::core_blocks) prev_snapshot: Option<Value>,
+	pub(in crate::core_blocks) new_snapshot: Option<Value>,
+	pub(in crate::core_blocks) reason: String,
+	pub(in crate::core_blocks) ts: OffsetDateTime,
+}

--- a/packages/elf-service/src/core_blocks/types.rs
+++ b/packages/elf-service/src/core_blocks/types.rs
@@ -1,8 +1,5 @@
-use std::collections::HashMap;
-
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use sqlx::FromRow;
 use time::OffsetDateTime;
 use uuid::Uuid;
 
@@ -228,115 +225,6 @@ pub struct CoreBlockDetachResponse {
 	pub attachment_id: Uuid,
 	/// Whether an active attachment was detached.
 	pub detached: bool,
-}
-
-#[derive(Clone, Debug, FromRow)]
-pub(super) struct CoreBlockRow {
-	pub(super) block_id: Uuid,
-	pub(super) tenant_id: String,
-	pub(super) project_id: String,
-	pub(super) agent_id: String,
-	pub(super) scope: String,
-	pub(super) key: String,
-	pub(super) title: String,
-	pub(super) content: String,
-	pub(super) source_ref: Value,
-	pub(super) status: String,
-	pub(super) created_at: OffsetDateTime,
-	pub(super) updated_at: OffsetDateTime,
-}
-impl CoreBlockRow {
-	pub(super) fn into_record(self) -> CoreBlockRecord {
-		CoreBlockRecord {
-			block_id: self.block_id,
-			tenant_id: self.tenant_id,
-			project_id: self.project_id,
-			agent_id: self.agent_id,
-			scope: self.scope,
-			key: self.key,
-			title: self.title,
-			content: self.content,
-			source_ref: self.source_ref,
-			status: self.status,
-			created_at: self.created_at,
-			updated_at: self.updated_at,
-		}
-	}
-}
-
-#[derive(Clone, Debug, FromRow)]
-pub(super) struct CoreBlockAttachmentRow {
-	pub(super) attachment_id: Uuid,
-	pub(super) block_id: Uuid,
-	pub(super) tenant_id: String,
-	pub(super) project_id: String,
-	pub(super) agent_id: String,
-	pub(super) read_profile: String,
-	pub(super) attached_by_agent_id: String,
-	pub(super) attached_at: OffsetDateTime,
-	pub(super) detached_by_agent_id: Option<String>,
-	pub(super) detached_at: Option<OffsetDateTime>,
-}
-
-#[derive(Clone, Debug, FromRow)]
-pub(super) struct CoreBlockJoinedRow {
-	pub(super) attachment_id: Uuid,
-	pub(super) attachment_agent_id: String,
-	pub(super) attached_by_agent_id: String,
-	pub(super) attached_at: OffsetDateTime,
-	pub(super) block_id: Uuid,
-	pub(super) tenant_id: String,
-	pub(super) project_id: String,
-	pub(super) agent_id: String,
-	pub(super) scope: String,
-	pub(super) key: String,
-	pub(super) title: String,
-	pub(super) content: String,
-	pub(super) source_ref: Value,
-	pub(super) status: String,
-	pub(super) created_at: OffsetDateTime,
-	pub(super) updated_at: OffsetDateTime,
-}
-impl CoreBlockJoinedRow {
-	pub(super) fn into_item(
-		self,
-		audit_by_block: &HashMap<Uuid, Vec<CoreBlockAuditEvent>>,
-	) -> CoreBlockItem {
-		let audit_history = audit_by_block.get(&self.block_id).cloned().unwrap_or_else(Vec::new);
-
-		CoreBlockItem {
-			block_id: self.block_id,
-			attachment_id: self.attachment_id,
-			tenant_id: self.tenant_id,
-			project_id: self.project_id,
-			agent_id: self.agent_id,
-			scope: self.scope,
-			key: self.key,
-			title: self.title,
-			content: self.content,
-			source_ref: self.source_ref,
-			status: self.status,
-			updated_at: self.updated_at,
-			attached_at: self.attached_at,
-			attached_by_agent_id: self.attached_by_agent_id,
-			audit_history,
-		}
-	}
-}
-
-#[derive(Clone, Debug, FromRow)]
-pub(super) struct CoreBlockEventRow {
-	pub(super) event_id: Uuid,
-	pub(super) block_id: Uuid,
-	pub(super) attachment_id: Option<Uuid>,
-	pub(super) actor_agent_id: String,
-	pub(super) event_type: String,
-	pub(super) target_agent_id: Option<String>,
-	pub(super) read_profile: Option<String>,
-	pub(super) prev_snapshot: Option<Value>,
-	pub(super) new_snapshot: Option<Value>,
-	pub(super) reason: String,
-	pub(super) ts: OffsetDateTime,
 }
 
 pub(super) struct PreparedGetRequest {

--- a/packages/elf-service/src/core_blocks/validation.rs
+++ b/packages/elf-service/src/core_blocks/validation.rs
@@ -5,10 +5,13 @@ use serde_json::Value;
 use crate::{
 	Error, Result,
 	access::{self, ORG_PROJECT_ID},
-	core_blocks::types::{
-		CoreBlockAttachRequest, CoreBlockAttachmentRow, CoreBlockDetachRequest, CoreBlockJoinedRow,
-		CoreBlockRow, CoreBlockUpsertRequest, CoreBlocksGetRequest, MAX_CORE_BLOCK_CONTENT_CHARS,
-		PreparedAttachRequest, PreparedDetachRequest, PreparedGetRequest, PreparedUpsertRequest,
+	core_blocks::{
+		rows::{CoreBlockAttachmentRow, CoreBlockJoinedRow, CoreBlockRow},
+		types::{
+			CoreBlockAttachRequest, CoreBlockDetachRequest, CoreBlockUpsertRequest,
+			CoreBlocksGetRequest, MAX_CORE_BLOCK_CONTENT_CHARS, PreparedAttachRequest,
+			PreparedDetachRequest, PreparedGetRequest, PreparedUpsertRequest,
+		},
 	},
 	search,
 };


### PR DESCRIPTION
## Summary

- Move internal core block SQL row carriers from `core_blocks/types.rs` into `core_blocks/rows.rs`.
- Keep `rows` private to the `core_blocks` module and scoped with `pub(in crate::core_blocks)`.
- Preserve the public `core_blocks` API re-exports and leave public DTOs/prepared request types in `types.rs`.

## Validation

- `cargo make fmt-rust`
- `cargo make check-rust`
- `cargo make lint-vstyle`
- `cargo make lint-rust`
- `cargo make test-rust`
- `cargo make check`
- `cargo make test-rust-integration`
- `cargo make check-trace-gate`
- `git diff --cached --check`
