### PR TITLE
Split consolidation proposal review storage

### DIFF
--- a/packages/elf-storage/src/consolidation.rs
+++ b/packages/elf-storage/src/consolidation.rs
@@ -1,6 +1,7 @@
 //! Consolidation run and proposal persistence queries.
 
 mod jobs;
+mod proposal_reviews;
 mod proposals;
 mod runs;
 mod sql;
@@ -11,11 +12,13 @@ pub use self::{
 		claim_next_consolidation_run_job, insert_consolidation_run_job,
 		mark_consolidation_run_job_done, mark_consolidation_run_job_failed,
 	},
-	proposals::{
-		get_consolidation_proposal, insert_consolidation_proposal,
+	proposal_reviews::{
 		insert_consolidation_proposal_review_event, list_consolidation_proposal_review_events,
-		list_consolidation_proposals, lock_consolidation_proposal,
-		update_consolidation_proposal_review, update_consolidation_proposal_target_ref,
+	},
+	proposals::{
+		get_consolidation_proposal, insert_consolidation_proposal, list_consolidation_proposals,
+		lock_consolidation_proposal, update_consolidation_proposal_review,
+		update_consolidation_proposal_target_ref,
 	},
 	runs::{
 		get_consolidation_run, insert_consolidation_run, list_consolidation_runs,

--- a/packages/elf-storage/src/consolidation/proposal_reviews.rs
+++ b/packages/elf-storage/src/consolidation/proposal_reviews.rs
@@ -1,0 +1,86 @@
+use sqlx::PgExecutor;
+use uuid::Uuid;
+
+use crate::{
+	Result, consolidation::types::ConsolidationProposalReviewEventInsert,
+	models::ConsolidationProposalReviewEvent,
+};
+
+/// Inserts one proposal review audit event.
+pub async fn insert_consolidation_proposal_review_event<'e, E>(
+	executor: E,
+	args: ConsolidationProposalReviewEventInsert<'_>,
+) -> Result<()>
+where
+	E: PgExecutor<'e>,
+{
+	sqlx::query(
+		"\
+INSERT INTO consolidation_proposal_reviews (
+	review_id,
+	proposal_id,
+	run_id,
+	tenant_id,
+	project_id,
+	reviewer_agent_id,
+	action,
+	from_review_state,
+	to_review_state,
+	review_comment,
+	created_at
+)
+VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)",
+	)
+	.bind(args.review_id)
+	.bind(args.proposal_id)
+	.bind(args.run_id)
+	.bind(args.tenant_id)
+	.bind(args.project_id)
+	.bind(args.reviewer_agent_id)
+	.bind(args.action)
+	.bind(args.from_review_state)
+	.bind(args.to_review_state)
+	.bind(args.review_comment)
+	.bind(args.created_at)
+	.execute(executor)
+	.await?;
+
+	Ok(())
+}
+
+/// Lists review events for one consolidation proposal.
+pub async fn list_consolidation_proposal_review_events<'e, E>(
+	executor: E,
+	tenant_id: &str,
+	project_id: &str,
+	proposal_id: Uuid,
+) -> Result<Vec<ConsolidationProposalReviewEvent>>
+where
+	E: PgExecutor<'e>,
+{
+	let rows = sqlx::query_as::<_, ConsolidationProposalReviewEvent>(
+		"\
+SELECT
+	review_id,
+	proposal_id,
+	run_id,
+	tenant_id,
+	project_id,
+	reviewer_agent_id,
+	action,
+	from_review_state,
+	to_review_state,
+	review_comment,
+	created_at
+FROM consolidation_proposal_reviews
+WHERE tenant_id = $1 AND project_id = $2 AND proposal_id = $3
+ORDER BY created_at ASC, review_id ASC",
+	)
+	.bind(tenant_id)
+	.bind(project_id)
+	.bind(proposal_id)
+	.fetch_all(executor)
+	.await?;
+
+	Ok(rows)
+}

--- a/packages/elf-storage/src/consolidation/proposals.rs
+++ b/packages/elf-storage/src/consolidation/proposals.rs
@@ -5,12 +5,9 @@ use crate::{
 	Result,
 	consolidation::{
 		sql::CONSOLIDATION_PROPOSAL_SELECT,
-		types::{
-			ConsolidationProposalReviewEventInsert, ConsolidationProposalReviewUpdate,
-			ConsolidationProposalTargetRefUpdate,
-		},
+		types::{ConsolidationProposalReviewUpdate, ConsolidationProposalTargetRefUpdate},
 	},
-	models::{ConsolidationProposal, ConsolidationProposalReviewEvent},
+	models::ConsolidationProposal,
 };
 
 /// Inserts one consolidation proposal.
@@ -315,83 +312,4 @@ RETURNING
 	.await?;
 
 	Ok(row)
-}
-
-/// Inserts one proposal review audit event.
-pub async fn insert_consolidation_proposal_review_event<'e, E>(
-	executor: E,
-	args: ConsolidationProposalReviewEventInsert<'_>,
-) -> Result<()>
-where
-	E: PgExecutor<'e>,
-{
-	sqlx::query(
-		"\
-INSERT INTO consolidation_proposal_reviews (
-	review_id,
-	proposal_id,
-	run_id,
-	tenant_id,
-	project_id,
-	reviewer_agent_id,
-	action,
-	from_review_state,
-	to_review_state,
-	review_comment,
-	created_at
-)
-VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)",
-	)
-	.bind(args.review_id)
-	.bind(args.proposal_id)
-	.bind(args.run_id)
-	.bind(args.tenant_id)
-	.bind(args.project_id)
-	.bind(args.reviewer_agent_id)
-	.bind(args.action)
-	.bind(args.from_review_state)
-	.bind(args.to_review_state)
-	.bind(args.review_comment)
-	.bind(args.created_at)
-	.execute(executor)
-	.await?;
-
-	Ok(())
-}
-
-/// Lists review events for one consolidation proposal.
-pub async fn list_consolidation_proposal_review_events<'e, E>(
-	executor: E,
-	tenant_id: &str,
-	project_id: &str,
-	proposal_id: Uuid,
-) -> Result<Vec<ConsolidationProposalReviewEvent>>
-where
-	E: PgExecutor<'e>,
-{
-	let rows = sqlx::query_as::<_, ConsolidationProposalReviewEvent>(
-		"\
-SELECT
-	review_id,
-	proposal_id,
-	run_id,
-	tenant_id,
-	project_id,
-	reviewer_agent_id,
-	action,
-	from_review_state,
-	to_review_state,
-	review_comment,
-	created_at
-FROM consolidation_proposal_reviews
-WHERE tenant_id = $1 AND project_id = $2 AND proposal_id = $3
-ORDER BY created_at ASC, review_id ASC",
-	)
-	.bind(tenant_id)
-	.bind(project_id)
-	.bind(proposal_id)
-	.fetch_all(executor)
-	.await?;
-
-	Ok(rows)
 }


### PR DESCRIPTION
## Summary
- move consolidation proposal review-event insert/list persistence into a private sibling module
- keep the public elf_storage::consolidation re-exports unchanged
- reduce proposals.rs to proposal row persistence only

## Validation
- cargo make fmt-rust
- cargo make check-rust
- cargo make lint-vstyle
- cargo make lint-rust
- cargo make test-rust: 370 passed / 92 skipped
- cargo make check: 370 passed / 92 skipped
- cargo make test-rust-integration: 92 passed / 370 skipped
- cargo make check-trace-gate
- git diff --cached --check

Skeptic review found no blockers and recommended commit.