### PR TITLE
Split CLI benchmark args

### DIFF
--- a/apps/elf-cli/src/args.rs
+++ b/apps/elf-cli/src/args.rs
@@ -1,4 +1,8 @@
-use std::path::PathBuf;
+mod benchmark;
+
+pub(crate) use self::benchmark::{
+	BenchmarkArgs, BenchmarkCommand, BenchmarkReportArgs, BenchmarkRunArgs,
+};
 
 use clap::{Args, Parser, Subcommand, ValueEnum};
 
@@ -168,54 +172,6 @@ pub(crate) struct BackfillArgs {
 }
 
 #[derive(Debug, Args)]
-pub(crate) struct BenchmarkArgs {
-	#[command(subcommand)]
-	pub(crate) command: BenchmarkCommand,
-}
-
-#[derive(Debug, Args)]
-pub(crate) struct BenchmarkRunArgs {
-	#[command(flatten)]
-	pub(crate) output: OutputArgs,
-	/// Benchmark task wrapper to run.
-	#[arg(long, value_enum, default_value_t = BenchmarkRunKind::Live)]
-	pub(crate) kind: BenchmarkRunKind,
-	/// Project filter passed to ELF_BASELINE_PROJECTS.
-	#[arg(long)]
-	pub(crate) projects: Option<String>,
-	/// Corpus profile passed to ELF_BASELINE_PROFILE.
-	#[arg(long)]
-	pub(crate) profile: Option<String>,
-	/// Private production corpus manifest path.
-	#[arg(long)]
-	pub(crate) production_corpus_manifest: Option<PathBuf>,
-	/// Markdown addendum path for production-private-addendum.
-	#[arg(long)]
-	pub(crate) private_addendum: Option<PathBuf>,
-	/// Soak duration override in seconds.
-	#[arg(long)]
-	pub(crate) soak_seconds: Option<u32>,
-	/// Print the resolved task and environment without running it.
-	#[arg(long)]
-	pub(crate) dry_run: bool,
-}
-
-#[derive(Debug, Args)]
-pub(crate) struct BenchmarkReportArgs {
-	#[command(flatten)]
-	pub(crate) output: OutputArgs,
-	/// Source live-baseline report JSON path.
-	#[arg(long)]
-	pub(crate) report: Option<PathBuf>,
-	/// Markdown output path.
-	#[arg(long)]
-	pub(crate) out: Option<PathBuf>,
-	/// Print the resolved task and environment without running it.
-	#[arg(long)]
-	pub(crate) dry_run: bool,
-}
-
-#[derive(Debug, Args)]
 pub(crate) struct DiagnosticsArgs {
 	#[command(subcommand)]
 	pub(crate) command: DiagnosticsCommand,
@@ -352,36 +308,6 @@ impl PayloadLevel {
 			Self::L0 => "l0",
 			Self::L1 => "l1",
 			Self::L2 => "l2",
-		}
-	}
-}
-
-#[derive(Debug, Subcommand)]
-#[command(rename_all = "kebab")]
-pub(crate) enum BenchmarkCommand {
-	/// Run one checked-in Docker baseline task.
-	Run(BenchmarkRunArgs),
-	/// Render Markdown from a live-baseline JSON report.
-	Report(BenchmarkReportArgs),
-}
-
-#[derive(Clone, Copy, Debug, ValueEnum)]
-#[value(rename_all = "kebab")]
-pub(crate) enum BenchmarkRunKind {
-	Live,
-	ProductionSynthetic,
-	ProductionPrivate,
-	ProductionPrivateAddendum,
-	Soak,
-}
-impl BenchmarkRunKind {
-	pub(crate) fn task_name(self) -> &'static str {
-		match self {
-			Self::Live => "baseline-live-docker",
-			Self::ProductionSynthetic => "baseline-production-synthetic",
-			Self::ProductionPrivate => "baseline-production-private",
-			Self::ProductionPrivateAddendum => "baseline-production-private-addendum",
-			Self::Soak => "baseline-soak-docker",
 		}
 	}
 }

--- a/apps/elf-cli/src/args/benchmark.rs
+++ b/apps/elf-cli/src/args/benchmark.rs
@@ -1,0 +1,83 @@
+use std::path::PathBuf;
+
+use clap::{Args, Subcommand, ValueEnum};
+
+use crate::args::OutputArgs;
+
+#[derive(Debug, Args)]
+pub(crate) struct BenchmarkArgs {
+	#[command(subcommand)]
+	pub(crate) command: BenchmarkCommand,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct BenchmarkRunArgs {
+	#[command(flatten)]
+	pub(crate) output: OutputArgs,
+	/// Benchmark task wrapper to run.
+	#[arg(long, value_enum, default_value_t = BenchmarkRunKind::Live)]
+	pub(crate) kind: BenchmarkRunKind,
+	/// Project filter passed to ELF_BASELINE_PROJECTS.
+	#[arg(long)]
+	pub(crate) projects: Option<String>,
+	/// Corpus profile passed to ELF_BASELINE_PROFILE.
+	#[arg(long)]
+	pub(crate) profile: Option<String>,
+	/// Private production corpus manifest path.
+	#[arg(long)]
+	pub(crate) production_corpus_manifest: Option<PathBuf>,
+	/// Markdown addendum path for production-private-addendum.
+	#[arg(long)]
+	pub(crate) private_addendum: Option<PathBuf>,
+	/// Soak duration override in seconds.
+	#[arg(long)]
+	pub(crate) soak_seconds: Option<u32>,
+	/// Print the resolved task and environment without running it.
+	#[arg(long)]
+	pub(crate) dry_run: bool,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct BenchmarkReportArgs {
+	#[command(flatten)]
+	pub(crate) output: OutputArgs,
+	/// Source live-baseline report JSON path.
+	#[arg(long)]
+	pub(crate) report: Option<PathBuf>,
+	/// Markdown output path.
+	#[arg(long)]
+	pub(crate) out: Option<PathBuf>,
+	/// Print the resolved task and environment without running it.
+	#[arg(long)]
+	pub(crate) dry_run: bool,
+}
+
+#[derive(Debug, Subcommand)]
+#[command(rename_all = "kebab")]
+pub(crate) enum BenchmarkCommand {
+	/// Run one checked-in Docker baseline task.
+	Run(BenchmarkRunArgs),
+	/// Render Markdown from a live-baseline JSON report.
+	Report(BenchmarkReportArgs),
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+#[value(rename_all = "kebab")]
+pub(crate) enum BenchmarkRunKind {
+	Live,
+	ProductionSynthetic,
+	ProductionPrivate,
+	ProductionPrivateAddendum,
+	Soak,
+}
+impl BenchmarkRunKind {
+	pub(crate) fn task_name(self) -> &'static str {
+		match self {
+			Self::Live => "baseline-live-docker",
+			Self::ProductionSynthetic => "baseline-production-synthetic",
+			Self::ProductionPrivate => "baseline-production-private",
+			Self::ProductionPrivateAddendum => "baseline-production-private-addendum",
+			Self::Soak => "baseline-soak-docker",
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- move ELF CLI benchmark clap argument models into a private child module
- keep crate-local `crate::args::{BenchmarkArgs, BenchmarkCommand, BenchmarkReportArgs, BenchmarkRunArgs}` imports working
- keep benchmark run/report task mapping behavior unchanged

## Validation
- cargo make fmt-rust
- cargo make check-rust
- cargo make lint-vstyle
- cargo make lint-rust
- cargo make test-rust: 370 passed / 92 skipped
- cargo make check: 370 passed / 92 skipped
- cargo make test-rust-integration: 92 passed / 370 skipped
- cargo run -p elf -- benchmark --help
- cargo run -p elf -- benchmark run --dry-run --pretty
- cargo run -p elf -- benchmark report --dry-run --pretty
- cargo make check-trace-gate
- git diff --cached --check

Skeptic review found no blockers and recommended commit.
