### PR TITLE
Split worker trace cleanup

### DIFF
--- a/apps/elf-worker/src/worker/trace_jobs.rs
+++ b/apps/elf-worker/src/worker/trace_jobs.rs
@@ -1,5 +1,12 @@
+mod cleanup;
+
+pub(super) use cleanup::{
+	purge_expired_cache, purge_expired_search_sessions, purge_expired_trace_candidates,
+	purge_expired_traces,
+};
+
 use crate::worker::{
-	self, Db, OffsetDateTime, PgConnection, PgExecutor, QueryBuilder, Result, TraceCandidateInsert,
+	self, Db, PgConnection, PgExecutor, QueryBuilder, Result, TraceCandidateInsert,
 	TraceCandidateRecord, TraceItemInsert, TraceItemRecord, TraceOutboxJob, TracePayload,
 	TraceRecord, TraceStageInsert, TraceStageItemInsert, TraceTrajectoryStageRecord, Uuid, Value,
 };
@@ -305,58 +312,6 @@ INSERT INTO search_trace_candidates (
 	});
 	builder.push(" ON CONFLICT (candidate_id) DO NOTHING");
 	builder.build().execute(executor).await?;
-
-	Ok(())
-}
-
-pub(super) async fn purge_expired_trace_candidates(db: &Db, now: OffsetDateTime) -> Result<()> {
-	let result = sqlx::query("DELETE FROM search_trace_candidates WHERE expires_at <= $1")
-		.bind(now)
-		.execute(&db.pool)
-		.await?;
-
-	if result.rows_affected() > 0 {
-		tracing::info!(count = result.rows_affected(), "Purged expired search trace candidates.");
-	}
-
-	Ok(())
-}
-
-pub(super) async fn purge_expired_traces(db: &Db, now: OffsetDateTime) -> Result<()> {
-	let result = sqlx::query("DELETE FROM search_traces WHERE expires_at <= $1")
-		.bind(now)
-		.execute(&db.pool)
-		.await?;
-
-	if result.rows_affected() > 0 {
-		tracing::info!(count = result.rows_affected(), "Purged expired search traces.");
-	}
-
-	Ok(())
-}
-
-pub(super) async fn purge_expired_cache(db: &Db, now: OffsetDateTime) -> Result<()> {
-	let result = sqlx::query("DELETE FROM llm_cache WHERE expires_at <= $1")
-		.bind(now)
-		.execute(&db.pool)
-		.await?;
-
-	if result.rows_affected() > 0 {
-		tracing::info!(count = result.rows_affected(), "Purged expired LLM cache entries.");
-	}
-
-	Ok(())
-}
-
-pub(super) async fn purge_expired_search_sessions(db: &Db, now: OffsetDateTime) -> Result<()> {
-	let result = sqlx::query("DELETE FROM search_sessions WHERE expires_at <= $1")
-		.bind(now)
-		.execute(&db.pool)
-		.await?;
-
-	if result.rows_affected() > 0 {
-		tracing::info!(count = result.rows_affected(), "Purged expired search sessions.");
-	}
 
 	Ok(())
 }

--- a/apps/elf-worker/src/worker/trace_jobs/cleanup.rs
+++ b/apps/elf-worker/src/worker/trace_jobs/cleanup.rs
@@ -1,0 +1,59 @@
+use crate::worker::{Db, OffsetDateTime, Result};
+
+pub(in crate::worker) async fn purge_expired_trace_candidates(
+	db: &Db,
+	now: OffsetDateTime,
+) -> Result<()> {
+	let result = sqlx::query("DELETE FROM search_trace_candidates WHERE expires_at <= $1")
+		.bind(now)
+		.execute(&db.pool)
+		.await?;
+
+	if result.rows_affected() > 0 {
+		tracing::info!(count = result.rows_affected(), "Purged expired search trace candidates.");
+	}
+
+	Ok(())
+}
+
+pub(in crate::worker) async fn purge_expired_traces(db: &Db, now: OffsetDateTime) -> Result<()> {
+	let result = sqlx::query("DELETE FROM search_traces WHERE expires_at <= $1")
+		.bind(now)
+		.execute(&db.pool)
+		.await?;
+
+	if result.rows_affected() > 0 {
+		tracing::info!(count = result.rows_affected(), "Purged expired search traces.");
+	}
+
+	Ok(())
+}
+
+pub(in crate::worker) async fn purge_expired_cache(db: &Db, now: OffsetDateTime) -> Result<()> {
+	let result = sqlx::query("DELETE FROM llm_cache WHERE expires_at <= $1")
+		.bind(now)
+		.execute(&db.pool)
+		.await?;
+
+	if result.rows_affected() > 0 {
+		tracing::info!(count = result.rows_affected(), "Purged expired LLM cache entries.");
+	}
+
+	Ok(())
+}
+
+pub(in crate::worker) async fn purge_expired_search_sessions(
+	db: &Db,
+	now: OffsetDateTime,
+) -> Result<()> {
+	let result = sqlx::query("DELETE FROM search_sessions WHERE expires_at <= $1")
+		.bind(now)
+		.execute(&db.pool)
+		.await?;
+
+	if result.rows_affected() > 0 {
+		tracing::info!(count = result.rows_affected(), "Purged expired search sessions.");
+	}
+
+	Ok(())
+}


### PR DESCRIPTION
## Summary

- Split worker trace expiry cleanup helpers into `apps/elf-worker/src/worker/trace_jobs/cleanup.rs`.
- Preserve the existing `worker::purge_expired_*` call surface through the `trace_jobs` re-export.
- Keep cleanup SQL, binding, logging, and return behavior unchanged.

## Validation

- `cargo make fmt-rust`
- `cargo check -p elf-worker --all-targets --all-features`
- `cargo make fmt-rust-check`
- `cargo make check-rust`
- `cargo make lint-vstyle`
- `git diff --check`
- `cargo make lint-rust`
- `cargo make test-rust`
- `cargo make check`
- `cargo make test-rust-integration`
- `cargo make check-trace-gate`
- staged skeptic review: pass, no blockers or risks
