### PR TITLE
Split progressive search session types

### DIFF
--- a/packages/elf-service/src/progressive_search/types.rs
+++ b/packages/elf-service/src/progressive_search/types.rs
@@ -1,15 +1,18 @@
+mod session;
+
+pub(super) use session::{
+	HitItem, NewSearchSession, SESSION_ABSOLUTE_TTL_HOURS, SESSION_SLIDING_TTL_HOURS,
+	SearchSession, SearchSessionItemRecord, SearchSessionRow, SearchSessionizePath,
+	SearchSessionizedOutput,
+};
+
 use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
-use sqlx::FromRow;
 use time::OffsetDateTime;
 use uuid::Uuid;
 
 use crate::{NoteFetchResponse, PayloadLevel, QueryPlan, SearchTrajectorySummary};
-
-pub(super) const SESSION_SLIDING_TTL_HOURS: i64 = 6;
-pub(super) const SESSION_ABSOLUTE_TTL_HOURS: i64 = 24;
 
 /// Lightweight session-storable search hit used by progressive-search APIs.
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -241,105 +244,4 @@ pub struct SearchDetailsResponse {
 	pub expires_at: OffsetDateTime,
 	/// Per-note results.
 	pub results: Vec<SearchDetailsResult>,
-}
-
-pub(super) struct HitItem {
-	pub(super) note_id: Uuid,
-	pub(super) chunk_id: Uuid,
-	pub(super) rank: u32,
-	pub(super) final_score: f32,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(super) enum SearchSessionizePath {
-	Quick,
-	Planned,
-}
-
-pub(super) struct SearchSessionizedOutput {
-	pub(super) index: SearchIndexResponse,
-	pub(super) query_plan: Option<QueryPlan>,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub(super) struct SearchSessionItemRecord {
-	pub(super) rank: u32,
-	pub(super) note_id: Uuid,
-	pub(super) chunk_id: Uuid,
-	pub(super) final_score: f32,
-	#[serde(with = "crate::time_serde")]
-	pub(super) updated_at: OffsetDateTime,
-	#[serde(with = "crate::time_serde::option")]
-	pub(super) expires_at: Option<OffsetDateTime>,
-	pub(super) r#type: String,
-	pub(super) key: Option<String>,
-	pub(super) scope: String,
-	pub(super) importance: f32,
-	pub(super) confidence: f32,
-	pub(super) summary: String,
-}
-impl SearchSessionItemRecord {
-	pub(super) fn to_index_item(&self) -> SearchIndexItem {
-		SearchIndexItem {
-			note_id: self.note_id,
-			r#type: self.r#type.clone(),
-			key: self.key.clone(),
-			scope: self.scope.clone(),
-			importance: self.importance,
-			confidence: self.confidence,
-			updated_at: self.updated_at,
-			expires_at: self.expires_at,
-			final_score: self.final_score,
-			summary: self.summary.clone(),
-		}
-	}
-}
-
-pub(super) struct SearchSession {
-	pub(super) search_session_id: Uuid,
-	pub(super) trace_id: Uuid,
-	pub(super) tenant_id: String,
-	pub(super) project_id: String,
-	pub(super) agent_id: String,
-	pub(super) read_profile: String,
-	pub(super) query: String,
-	pub(super) mode: SearchSessionMode,
-	pub(super) trajectory_summary: Option<SearchTrajectorySummary>,
-	pub(super) query_plan: Option<QueryPlan>,
-	pub(super) items: Vec<SearchSessionItemRecord>,
-	pub(super) created_at: OffsetDateTime,
-	pub(super) expires_at: OffsetDateTime,
-}
-
-#[derive(FromRow)]
-pub(super) struct SearchSessionRow {
-	pub(super) search_session_id: Uuid,
-	pub(super) trace_id: Uuid,
-	pub(super) tenant_id: String,
-	pub(super) project_id: String,
-	pub(super) agent_id: String,
-	pub(super) read_profile: String,
-	pub(super) query: String,
-	pub(super) mode: String,
-	pub(super) trajectory_summary: Option<Value>,
-	pub(super) query_plan: Option<Value>,
-	pub(super) items: Value,
-	pub(super) created_at: OffsetDateTime,
-	pub(super) expires_at: OffsetDateTime,
-}
-
-pub(super) struct NewSearchSession<'a> {
-	pub(super) search_session_id: Uuid,
-	pub(super) trace_id: Uuid,
-	pub(super) tenant_id: &'a str,
-	pub(super) project_id: &'a str,
-	pub(super) agent_id: &'a str,
-	pub(super) read_profile: &'a str,
-	pub(super) query: &'a str,
-	pub(super) mode: SearchSessionMode,
-	pub(super) trajectory_summary: Option<&'a SearchTrajectorySummary>,
-	pub(super) query_plan: Option<&'a QueryPlan>,
-	pub(super) items: &'a [SearchSessionItemRecord],
-	pub(super) created_at: OffsetDateTime,
-	pub(super) expires_at: OffsetDateTime,
 }

--- a/packages/elf-service/src/progressive_search/types/session.rs
+++ b/packages/elf-service/src/progressive_search/types/session.rs
@@ -1,0 +1,114 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sqlx::FromRow;
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+use crate::{
+	QueryPlan, SearchTrajectorySummary,
+	progressive_search::types::{SearchIndexItem, SearchIndexResponse, SearchSessionMode},
+};
+
+pub(in crate::progressive_search) const SESSION_SLIDING_TTL_HOURS: i64 = 6;
+pub(in crate::progressive_search) const SESSION_ABSOLUTE_TTL_HOURS: i64 = 24;
+
+pub(in crate::progressive_search) struct HitItem {
+	pub(in crate::progressive_search) note_id: Uuid,
+	pub(in crate::progressive_search) chunk_id: Uuid,
+	pub(in crate::progressive_search) rank: u32,
+	pub(in crate::progressive_search) final_score: f32,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(in crate::progressive_search) enum SearchSessionizePath {
+	Quick,
+	Planned,
+}
+
+pub(in crate::progressive_search) struct SearchSessionizedOutput {
+	pub(in crate::progressive_search) index: SearchIndexResponse,
+	pub(in crate::progressive_search) query_plan: Option<QueryPlan>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(in crate::progressive_search) struct SearchSessionItemRecord {
+	pub(in crate::progressive_search) rank: u32,
+	pub(in crate::progressive_search) note_id: Uuid,
+	pub(in crate::progressive_search) chunk_id: Uuid,
+	pub(in crate::progressive_search) final_score: f32,
+	#[serde(with = "crate::time_serde")]
+	pub(in crate::progressive_search) updated_at: OffsetDateTime,
+	#[serde(with = "crate::time_serde::option")]
+	pub(in crate::progressive_search) expires_at: Option<OffsetDateTime>,
+	pub(in crate::progressive_search) r#type: String,
+	pub(in crate::progressive_search) key: Option<String>,
+	pub(in crate::progressive_search) scope: String,
+	pub(in crate::progressive_search) importance: f32,
+	pub(in crate::progressive_search) confidence: f32,
+	pub(in crate::progressive_search) summary: String,
+}
+impl SearchSessionItemRecord {
+	pub(in crate::progressive_search) fn to_index_item(&self) -> SearchIndexItem {
+		SearchIndexItem {
+			note_id: self.note_id,
+			r#type: self.r#type.clone(),
+			key: self.key.clone(),
+			scope: self.scope.clone(),
+			importance: self.importance,
+			confidence: self.confidence,
+			updated_at: self.updated_at,
+			expires_at: self.expires_at,
+			final_score: self.final_score,
+			summary: self.summary.clone(),
+		}
+	}
+}
+
+pub(in crate::progressive_search) struct SearchSession {
+	pub(in crate::progressive_search) search_session_id: Uuid,
+	pub(in crate::progressive_search) trace_id: Uuid,
+	pub(in crate::progressive_search) tenant_id: String,
+	pub(in crate::progressive_search) project_id: String,
+	pub(in crate::progressive_search) agent_id: String,
+	pub(in crate::progressive_search) read_profile: String,
+	pub(in crate::progressive_search) query: String,
+	pub(in crate::progressive_search) mode: SearchSessionMode,
+	pub(in crate::progressive_search) trajectory_summary: Option<SearchTrajectorySummary>,
+	pub(in crate::progressive_search) query_plan: Option<QueryPlan>,
+	pub(in crate::progressive_search) items: Vec<SearchSessionItemRecord>,
+	pub(in crate::progressive_search) created_at: OffsetDateTime,
+	pub(in crate::progressive_search) expires_at: OffsetDateTime,
+}
+
+#[derive(FromRow)]
+pub(in crate::progressive_search) struct SearchSessionRow {
+	pub(in crate::progressive_search) search_session_id: Uuid,
+	pub(in crate::progressive_search) trace_id: Uuid,
+	pub(in crate::progressive_search) tenant_id: String,
+	pub(in crate::progressive_search) project_id: String,
+	pub(in crate::progressive_search) agent_id: String,
+	pub(in crate::progressive_search) read_profile: String,
+	pub(in crate::progressive_search) query: String,
+	pub(in crate::progressive_search) mode: String,
+	pub(in crate::progressive_search) trajectory_summary: Option<Value>,
+	pub(in crate::progressive_search) query_plan: Option<Value>,
+	pub(in crate::progressive_search) items: Value,
+	pub(in crate::progressive_search) created_at: OffsetDateTime,
+	pub(in crate::progressive_search) expires_at: OffsetDateTime,
+}
+
+pub(in crate::progressive_search) struct NewSearchSession<'a> {
+	pub(in crate::progressive_search) search_session_id: Uuid,
+	pub(in crate::progressive_search) trace_id: Uuid,
+	pub(in crate::progressive_search) tenant_id: &'a str,
+	pub(in crate::progressive_search) project_id: &'a str,
+	pub(in crate::progressive_search) agent_id: &'a str,
+	pub(in crate::progressive_search) read_profile: &'a str,
+	pub(in crate::progressive_search) query: &'a str,
+	pub(in crate::progressive_search) mode: SearchSessionMode,
+	pub(in crate::progressive_search) trajectory_summary: Option<&'a SearchTrajectorySummary>,
+	pub(in crate::progressive_search) query_plan: Option<&'a QueryPlan>,
+	pub(in crate::progressive_search) items: &'a [SearchSessionItemRecord],
+	pub(in crate::progressive_search) created_at: OffsetDateTime,
+	pub(in crate::progressive_search) expires_at: OffsetDateTime,
+}


### PR DESCRIPTION
## Summary

- Move progressive-search session/internal storage types into `types/session.rs`
- Keep the public progressive-search DTO surface in `types.rs`
- Re-export moved internals only inside `progressive_search`

## Validation

- `cargo make fmt-rust-check`
- `cargo make check-rust`
- `cargo make lint-vstyle`
- `git diff --check`
- `cargo make lint-rust`
- `cargo make test-rust` (370 passed, 92 skipped)
- `cargo make check`
- `cargo make test-rust-integration` (92 passed, 370 skipped)
- `cargo make check-trace-gate`
- Read-only scout and skeptic reviews
