### PR TITLE
Split consolidation run DTOs

### DIFF
--- a/packages/elf-service/src/consolidation/types.rs
+++ b/packages/elf-service/src/consolidation/types.rs
@@ -1,3 +1,10 @@
+mod runs;
+
+pub use runs::{
+	ConsolidationRunCreateRequest, ConsolidationRunCreateResponse, ConsolidationRunGetRequest,
+	ConsolidationRunResponse, ConsolidationRunsListRequest, ConsolidationRunsListResponse,
+};
+
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use time::OffsetDateTime;
@@ -8,35 +15,10 @@ use elf_domain::consolidation::{
 	ConsolidationProposalContract, ConsolidationProposalDiff, ConsolidationReviewAction,
 	ConsolidationReviewState, ConsolidationUnsupportedClaimFlag,
 };
-use elf_storage::models::{
-	ConsolidationProposal, ConsolidationProposalReviewEvent, ConsolidationRun,
-};
+use elf_storage::models::{ConsolidationProposal, ConsolidationProposalReviewEvent};
 
 pub(super) const DEFAULT_LIST_LIMIT: i64 = 50;
 pub(super) const MAX_LIST_LIMIT: i64 = 200;
-
-/// Request to create a fixture-backed consolidation run.
-#[derive(Clone, Debug, Deserialize)]
-pub struct ConsolidationRunCreateRequest {
-	/// Tenant that owns the run.
-	pub tenant_id: String,
-	/// Project that owns the run.
-	pub project_id: String,
-	/// Agent registering the run.
-	pub agent_id: String,
-	/// Job kind, such as `fixture` or `manual`.
-	pub job_kind: String,
-	/// Input references considered by the run.
-	pub input_refs: Vec<ConsolidationInputRef>,
-	#[serde(default = "empty_object")]
-	/// Aggregate source snapshot metadata for the run.
-	pub source_snapshot: Value,
-	/// Run lineage.
-	pub lineage: ConsolidationLineage,
-	#[serde(default)]
-	/// Fixture-generated proposals to persist with this run.
-	pub proposals: Vec<ConsolidationProposalInput>,
-}
 
 /// Fixture proposal input for a consolidation run.
 #[derive(Clone, Debug, Deserialize)]
@@ -83,99 +65,6 @@ impl ConsolidationProposalInput {
 			diff: self.diff,
 			target_ref: self.target_ref,
 			proposed_payload: self.proposed_payload,
-		}
-	}
-}
-
-/// Response returned after creating one consolidation run.
-#[derive(Clone, Debug, Serialize)]
-pub struct ConsolidationRunCreateResponse {
-	/// Created run.
-	pub run: ConsolidationRunResponse,
-	/// Enqueued worker job identifier.
-	pub job_id: Uuid,
-	/// Proposals stored with the run.
-	pub proposals: Vec<ConsolidationProposalResponse>,
-}
-
-/// Request to get one consolidation run.
-#[derive(Clone, Debug, Deserialize)]
-pub struct ConsolidationRunGetRequest {
-	/// Tenant that owns the run.
-	pub tenant_id: String,
-	/// Project that owns the run.
-	pub project_id: String,
-	/// Run identifier.
-	pub run_id: Uuid,
-}
-
-/// Request to list consolidation runs.
-#[derive(Clone, Debug, Deserialize)]
-pub struct ConsolidationRunsListRequest {
-	/// Tenant that owns the runs.
-	pub tenant_id: String,
-	/// Project that owns the runs.
-	pub project_id: String,
-	/// Maximum number of runs to return.
-	pub limit: Option<u32>,
-}
-
-/// Response returned by consolidation run listing.
-#[derive(Clone, Debug, Serialize)]
-pub struct ConsolidationRunsListResponse {
-	/// Returned runs.
-	pub runs: Vec<ConsolidationRunResponse>,
-}
-
-/// Public consolidation run DTO.
-#[derive(Clone, Debug, Serialize)]
-pub struct ConsolidationRunResponse {
-	/// Consolidation run identifier.
-	pub run_id: Uuid,
-	/// Tenant that owns the run.
-	pub tenant_id: String,
-	/// Project that owns the run.
-	pub project_id: String,
-	/// Agent that registered the run.
-	pub agent_id: String,
-	/// Versioned consolidation contract schema.
-	pub contract_schema: String,
-	/// Job kind, such as fixture or manual.
-	pub job_kind: String,
-	/// Current run state.
-	pub status: String,
-	/// Serialized input references.
-	pub input_refs: Value,
-	/// Aggregate source snapshot metadata.
-	pub source_snapshot: Value,
-	/// Serialized run lineage.
-	pub lineage: Value,
-	/// Structured error payload for failed runs.
-	pub error: Value,
-	/// Creation timestamp.
-	pub created_at: OffsetDateTime,
-	/// Last update timestamp.
-	pub updated_at: OffsetDateTime,
-	/// Completion timestamp for terminal runs.
-	pub completed_at: Option<OffsetDateTime>,
-}
-impl From<ConsolidationRun> for ConsolidationRunResponse {
-	fn from(run: ConsolidationRun) -> Self {
-		Self {
-			run_id: run.run_id,
-			tenant_id: run.tenant_id,
-			project_id: run.project_id,
-			agent_id: run.agent_id,
-			contract_schema: run.contract_schema,
-			job_kind: run.job_kind,
-			status: run.status,
-			input_refs: run.input_refs,
-			source_snapshot: run.source_snapshot,
-			lineage: run.lineage,
-			error: run.error,
-			created_at: run.created_at,
-			updated_at: run.updated_at,
-			completed_at: run.completed_at,
 		}
 	}
 }

--- a/packages/elf-service/src/consolidation/types/runs.rs
+++ b/packages/elf-service/src/consolidation/types/runs.rs
@@ -1,0 +1,126 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+use crate::consolidation::types::{
+	ConsolidationProposalInput, ConsolidationProposalResponse, empty_object,
+};
+use elf_domain::consolidation::{ConsolidationInputRef, ConsolidationLineage};
+use elf_storage::models::ConsolidationRun;
+
+/// Request to create a fixture-backed consolidation run.
+#[derive(Clone, Debug, Deserialize)]
+pub struct ConsolidationRunCreateRequest {
+	/// Tenant that owns the run.
+	pub tenant_id: String,
+	/// Project that owns the run.
+	pub project_id: String,
+	/// Agent registering the run.
+	pub agent_id: String,
+	/// Job kind, such as `fixture` or `manual`.
+	pub job_kind: String,
+	/// Input references considered by the run.
+	pub input_refs: Vec<ConsolidationInputRef>,
+	#[serde(default = "empty_object")]
+	/// Aggregate source snapshot metadata for the run.
+	pub source_snapshot: Value,
+	/// Run lineage.
+	pub lineage: ConsolidationLineage,
+	#[serde(default)]
+	/// Fixture-generated proposals to persist with this run.
+	pub proposals: Vec<ConsolidationProposalInput>,
+}
+
+/// Response returned after creating one consolidation run.
+#[derive(Clone, Debug, Serialize)]
+pub struct ConsolidationRunCreateResponse {
+	/// Created run.
+	pub run: ConsolidationRunResponse,
+	/// Enqueued worker job identifier.
+	pub job_id: Uuid,
+	/// Proposals stored with the run.
+	pub proposals: Vec<ConsolidationProposalResponse>,
+}
+
+/// Request to get one consolidation run.
+#[derive(Clone, Debug, Deserialize)]
+pub struct ConsolidationRunGetRequest {
+	/// Tenant that owns the run.
+	pub tenant_id: String,
+	/// Project that owns the run.
+	pub project_id: String,
+	/// Run identifier.
+	pub run_id: Uuid,
+}
+
+/// Request to list consolidation runs.
+#[derive(Clone, Debug, Deserialize)]
+pub struct ConsolidationRunsListRequest {
+	/// Tenant that owns the runs.
+	pub tenant_id: String,
+	/// Project that owns the runs.
+	pub project_id: String,
+	/// Maximum number of runs to return.
+	pub limit: Option<u32>,
+}
+
+/// Response returned by consolidation run listing.
+#[derive(Clone, Debug, Serialize)]
+pub struct ConsolidationRunsListResponse {
+	/// Returned runs.
+	pub runs: Vec<ConsolidationRunResponse>,
+}
+
+/// Public consolidation run DTO.
+#[derive(Clone, Debug, Serialize)]
+pub struct ConsolidationRunResponse {
+	/// Consolidation run identifier.
+	pub run_id: Uuid,
+	/// Tenant that owns the run.
+	pub tenant_id: String,
+	/// Project that owns the run.
+	pub project_id: String,
+	/// Agent that registered the run.
+	pub agent_id: String,
+	/// Versioned consolidation contract schema.
+	pub contract_schema: String,
+	/// Job kind, such as fixture or manual.
+	pub job_kind: String,
+	/// Current run state.
+	pub status: String,
+	/// Serialized input references.
+	pub input_refs: Value,
+	/// Aggregate source snapshot metadata.
+	pub source_snapshot: Value,
+	/// Serialized run lineage.
+	pub lineage: Value,
+	/// Structured error payload for failed runs.
+	pub error: Value,
+	/// Creation timestamp.
+	pub created_at: OffsetDateTime,
+	/// Last update timestamp.
+	pub updated_at: OffsetDateTime,
+	/// Completion timestamp for terminal runs.
+	pub completed_at: Option<OffsetDateTime>,
+}
+impl From<ConsolidationRun> for ConsolidationRunResponse {
+	fn from(run: ConsolidationRun) -> Self {
+		Self {
+			run_id: run.run_id,
+			tenant_id: run.tenant_id,
+			project_id: run.project_id,
+			agent_id: run.agent_id,
+			contract_schema: run.contract_schema,
+			job_kind: run.job_kind,
+			status: run.status,
+			input_refs: run.input_refs,
+			source_snapshot: run.source_snapshot,
+			lineage: run.lineage,
+			error: run.error,
+			created_at: run.created_at,
+			updated_at: run.updated_at,
+			completed_at: run.completed_at,
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Move consolidation run request/response DTOs into `types/runs.rs`
- Keep proposal/review/promotion DTOs in the parent `types.rs`
- Preserve the public consolidation re-export surface

## Validation

- `cargo make fmt-rust-check`
- `cargo make check-rust`
- `cargo make lint-vstyle`
- `git diff --check`
- `cargo make lint-rust`
- `cargo make test-rust` (370 passed, 92 skipped)
- `cargo make check`
- `cargo make test-rust-integration` (92 passed, 370 skipped)
- `cargo make check-trace-gate`
- Read-only scout and skeptic reviews
