### PR TITLE
Split real-world job consolidation report DTOs

### DIFF
--- a/apps/elf-eval/src/bin/real_world_job_benchmark/consolidation_reports.rs
+++ b/apps/elf-eval/src/bin/real_world_job_benchmark/consolidation_reports.rs
@@ -1,0 +1,35 @@
+use crate::{ConsolidationReviewAction, Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct ConsolidationJobReport {
+	pub(crate) proposal_count: usize,
+	pub(crate) proposal_usefulness: Option<f64>,
+	pub(crate) lineage_completeness: Option<f64>,
+	pub(crate) review_action_correctness: Option<f64>,
+	pub(crate) source_mutation_count: usize,
+	pub(crate) proposal_unsupported_claim_count: usize,
+	pub(crate) executable_gaps: Vec<ConsolidationExecutableGapReport>,
+	pub(crate) proposals: Vec<ConsolidationProposalReport>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct ConsolidationProposalReport {
+	pub(crate) proposal_id: String,
+	pub(crate) proposal_kind: String,
+	pub(crate) usefulness_score: f64,
+	pub(crate) min_usefulness_score: f64,
+	pub(crate) lineage_completeness: f64,
+	pub(crate) expected_review_action: ConsolidationReviewAction,
+	pub(crate) actual_review_action: ConsolidationReviewAction,
+	pub(crate) review_action_correct: bool,
+	pub(crate) source_mutation_count: usize,
+	pub(crate) unsupported_claim_count: usize,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct ConsolidationExecutableGapReport {
+	pub(crate) primitive: String,
+	pub(crate) follow_up_issue: String,
+	pub(crate) reason: String,
+	pub(crate) blocks_fixture_pass: bool,
+}

--- a/apps/elf-eval/src/bin/real_world_job_benchmark/job_reports.rs
+++ b/apps/elf-eval/src/bin/real_world_job_benchmark/job_reports.rs
@@ -1,6 +1,12 @@
+mod consolidation_reports;
+
+pub(super) use consolidation_reports::{
+	ConsolidationExecutableGapReport, ConsolidationJobReport, ConsolidationProposalReport,
+};
+
 use crate::{
-	AuthorityRecoveryDrillArtifact, ConsolidationReviewAction, CostReport, Deserialize,
-	OperatorDebugEvidence, Serialize, TraceExplainability, TypedStatus,
+	AuthorityRecoveryDrillArtifact, CostReport, Deserialize, OperatorDebugEvidence, Serialize,
+	TraceExplainability, TypedStatus,
 };
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -106,40 +112,6 @@ pub(super) struct RetrievalQualityReport {
 	pub(super) irrelevant_context_count: usize,
 	pub(super) irrelevant_context_ratio: f64,
 	pub(super) trap_context_count: usize,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub(super) struct ConsolidationJobReport {
-	pub(super) proposal_count: usize,
-	pub(super) proposal_usefulness: Option<f64>,
-	pub(super) lineage_completeness: Option<f64>,
-	pub(super) review_action_correctness: Option<f64>,
-	pub(super) source_mutation_count: usize,
-	pub(super) proposal_unsupported_claim_count: usize,
-	pub(super) executable_gaps: Vec<ConsolidationExecutableGapReport>,
-	pub(super) proposals: Vec<ConsolidationProposalReport>,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub(super) struct ConsolidationProposalReport {
-	pub(super) proposal_id: String,
-	pub(super) proposal_kind: String,
-	pub(super) usefulness_score: f64,
-	pub(super) min_usefulness_score: f64,
-	pub(super) lineage_completeness: f64,
-	pub(super) expected_review_action: ConsolidationReviewAction,
-	pub(super) actual_review_action: ConsolidationReviewAction,
-	pub(super) review_action_correct: bool,
-	pub(super) source_mutation_count: usize,
-	pub(super) unsupported_claim_count: usize,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub(super) struct ConsolidationExecutableGapReport {
-	pub(super) primitive: String,
-	pub(super) follow_up_issue: String,
-	pub(super) reason: String,
-	pub(super) blocks_fixture_pass: bool,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]


### PR DESCRIPTION
## Summary

- Split real-world job benchmark consolidation report DTOs into `consolidation_reports.rs`.
- Kept `job_reports.rs` as the parent report model surface with the same re-exported type names.
- Preserved derives, field names, field order, field types, serde behavior, and report generation logic.

## Validation

- `cargo make fmt-rust`
- `cargo make check-rust`
- `cargo make fmt-rust-check`
- `git diff --check`
- `cargo make lint-vstyle`
- `cargo make smoke-real-world-job-report`
- `cargo make lint-rust`
- `cargo make test-rust` (379 passed, 92 skipped)
- `cargo make check` (379 passed, 92 skipped)

## Review

- Scout selected consolidation report DTOs as a strong production module boundary.
- Skeptic passed with no findings after staged diff review.
