### PR TITLE
Complete dependency roll

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -65,10 +65,10 @@ jobs:
 
     steps:
       - name: Fetch latest code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Set up Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659
         with:
           cache: true
           rustflags: ""
@@ -79,12 +79,12 @@ jobs:
           sudo apt-get install -y --no-install-recommends postgresql-client jq
 
       - name: Install taplo
-        uses: taiki-e/install-action@15449e3094499af05d8d964a1c884208e4b8b595
+        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5
         with:
           tool: taplo
 
       - name: Install cargo-make
-        uses: taiki-e/install-action@15449e3094499af05d8d964a1c884208e4b8b595
+        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5
         with:
           tool: cargo-make
 

--- a/.github/workflows/external-memory-pattern-radar.yml
+++ b/.github/workflows/external-memory-pattern-radar.yml
@@ -19,16 +19,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch latest code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Set up Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659
         with:
           cache: true
           rustflags: ""
 
       - name: Install cargo-make
-        uses: taiki-e/install-action@15449e3094499af05d8d964a1c884208e4b8b595
+        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5
         with:
           tool: cargo-make
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -63,21 +63,21 @@ jobs:
           - 6334:6334
     steps:
       - name: Fetch latest code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Set up Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659
         with:
           cache: true
           rustflags: ''
 
       - name: Install nextest
-        uses: taiki-e/install-action@15449e3094499af05d8d964a1c884208e4b8b595
+        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5
         with:
           tool: nextest
 
       - name: Install cargo-make
-        uses: taiki-e/install-action@15449e3094499af05d8d964a1c884208e4b8b595
+        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5
         with:
           tool: cargo-make
 

--- a/.github/workflows/language.yml
+++ b/.github/workflows/language.yml
@@ -35,10 +35,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch latest code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Set up Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659
         with:
           cache: true
           rustflags: ''
@@ -48,7 +48,7 @@ jobs:
         run: rustup toolchain install nightly --component rustfmt
 
       - name: Install cargo-make
-        uses: taiki-e/install-action@15449e3094499af05d8d964a1c884208e4b8b595
+        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5
         with:
           tool: cargo-make
 
@@ -68,12 +68,12 @@ jobs:
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Install nextest
-        uses: taiki-e/install-action@15449e3094499af05d8d964a1c884208e4b8b595
+        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5
         with:
           tool: nextest
 
       - name: Install taplo
-        uses: taiki-e/install-action@15449e3094499af05d8d964a1c884208e4b8b595
+        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5
         with:
           tool: taplo
 

--- a/.github/workflows/nightly-harness-signals.yml
+++ b/.github/workflows/nightly-harness-signals.yml
@@ -48,10 +48,10 @@ jobs:
 
     steps:
       - name: Fetch latest code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Set up Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659
         with:
           cache: true
           rustflags: ""
@@ -62,7 +62,7 @@ jobs:
           sudo apt-get install -y --no-install-recommends postgresql-client jq
 
       - name: Install taplo
-        uses: taiki-e/install-action@15449e3094499af05d8d964a1c884208e4b8b595
+        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5
         with:
           tool: taplo
 

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -51,16 +51,16 @@ jobs:
           --health-retries 10
     steps:
       - name: Fetch latest code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Set up Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659
         with:
           cache: true
           rustflags: ''
 
       - name: Install cargo-make
-        uses: taiki-e/install-action@15449e3094499af05d8d964a1c884208e4b8b595
+        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5
         with:
           tool: cargo-make
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,10 +33,10 @@ jobs:
           ]
     steps:
       - name: Fetch latest code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Set up Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659
         with:
           cache: true
           components: rustfmt, clippy
@@ -113,7 +113,7 @@ jobs:
           mv ../MD5 .
 
       - name: Publish
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b
         with:
           discussion_category_name: Announcements
           generate_release_notes: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2752,9 +2752,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.8.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1f571c72940a19d9532fe52dbea8bc9912bf1d766c2970bb824056b86f3f59"
+checksum = "d52d21e5b342699bc4de690e6104fc4e43255e4e8420ff0f2cbb963aac09da6f"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2783,9 +2783,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.8.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aad0035b69380782d78ea95b508327e6deaa2235909053e596eea8f27b5e1d5"
+checksum = "6c68cec74c5b3ac73ff46375ae49e161637bda80bba70f0d5db641583bb308ee"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ color-eyre            = { version = "0.6" }
 qdrant-client         = { version = "1.18.0" }
 regex                 = { version = "1.12" }
 reqwest               = { version = "0.13", default-features = false, features = ["json", "query", "rustls"] }
-rmcp                  = { version = "1.7", features = ["transport-streamable-http-server"] }
+rmcp                  = { version = "2.0", features = ["transport-streamable-http-server"] }
 serde                 = { version = "1.0", features = ["derive"] }
 serde_json            = { version = "1.0" }
 sqlx                  = { version = "0.9", features = ["json", "postgres", "runtime-tokio", "time", "tls-rustls", "uuid"] }


### PR DESCRIPTION
## Summary
- bump `rmcp` to 2.0.0 and refresh `Cargo.lock`
- reconcile pending GitHub Actions dependency PRs with full-SHA pins:
  - `actions/checkout@v7.0.0` -> `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0`
  - `actions-rust-lang/setup-rust-toolchain@v1.17.0` -> `166cdcfd11aee3cb47222f9ddb555ce30ddb9659`
  - `taiki-e/install-action@v2.82.0` -> `b8cecb83565409bcc297b2df6e77f030b2a468d5`
  - `softprops/action-gh-release@v3.0.1` -> `718ea10b132b3b2eba29c1007bb80653f286566b`
- covers Dependabot PRs #286, #248, #224, #208, and #206

## Verification
- `cargo update --verbose`
- `cargo make fmt`
- `cargo make check`
- `cargo audit` (3 allowed warnings only: `number_prefix`, `paste`, `rustls-pemfile`)
- `cargo make check-trace-gate`
- `cargo make test-e2e`
- `cargo make test-rust-all`

## Notes
- `cargo update --verbose` still reports transitive unchanged crates `crypto-common v0.1.6` via `sqlx`/`sha2` and `matchit v0.8.4` via `axum`; these are upstream transitives, not direct manifest dependencies.
