### PR TITLE
Guard Knowledge Workspace memory candidates as review proposals

### DIFF
--- a/docs/log.md
+++ b/docs/log.md
@@ -170,3 +170,6 @@ logs.
 - Preserved historical benchmark evidence rows that recorded the former singular
   check command, and constrained docs task validation to allow only those exact
   legacy evidence references.
+- Added the XY-1153 Knowledge Workspace authority-boundary marker for changed-source
+  memory candidates so derived page deltas remain reviewable consolidation proposals
+  and cannot directly mutate Memory Authority or source evidence.

--- a/docs/spec/system_knowledge_pages_v1.md
+++ b/docs/spec/system_knowledge_pages_v1.md
@@ -176,6 +176,15 @@ nested source refs.
 - `allowed_variance`
 - `previous_version_diff`
 
+Knowledge delta memory candidates produced by changed-source watch/rebuild are
+review proposals only. Their proposed payload and diff must carry
+`elf.knowledge_delta.authority_boundary/v1` with
+`authority = "derived_non_authoritative"`,
+`review_surface = "consolidation_proposals"`,
+`promotion_required_for_memory_authority = true`,
+`direct_memory_ledger_mutation_allowed = false`, and
+`source_mutation_allowed = false`.
+
 `previous_version_diff` must use schema `elf.knowledge_page.version_diff/v1`.
 Initial rebuilds must set `available = false` and explain that no previous version
 exists. Later rebuilds must set `available = true` and include previous and new

--- a/packages/elf-service/src/knowledge/tests_helpers.rs
+++ b/packages/elf-service/src/knowledge/tests_helpers.rs
@@ -165,6 +165,14 @@ pub(super) fn assert_candidate_is_reviewable(candidate: &KnowledgeDeltaMemoryCan
 	assert_eq!(candidate.source_refs[0].kind.as_str(), "note");
 	assert_eq!(candidate.source_snapshot["source_mutation_allowed"], false);
 	assert_eq!(candidate.diff.after["reason"], "changed_claim");
+	assert_eq!(
+		candidate.diff.after["authority_boundary"]["review_surface"],
+		"consolidation_proposals"
+	);
 	assert_eq!(candidate.proposed_payload["type"], "plan");
+	assert_eq!(
+		candidate.proposed_payload["authority_boundary"]["authority"],
+		"derived_non_authoritative"
+	);
 	assert_eq!(candidate.proposed_payload["source_ref"]["schema"], "elf.knowledge_delta/v1");
 }

--- a/packages/elf-service/src/knowledge/tests_memory.rs
+++ b/packages/elf-service/src/knowledge/tests_memory.rs
@@ -25,7 +25,20 @@ fn memory_candidate_uses_reviewable_consolidation_proposal_contract() {
 
 	assert_eq!(proposal.apply_intent, ConsolidationApplyIntent::CreateDerivedNote);
 	assert_eq!(proposal.source_refs.len(), 1);
+	assert_eq!(proposal.diff.after["authority_boundary"]["authority"], "derived_non_authoritative");
+	assert_eq!(
+		proposal.diff.after["authority_boundary"]["direct_memory_ledger_mutation_allowed"],
+		false
+	);
 	assert_eq!(proposal.proposed_payload["source_ref"]["source_mutation_allowed"], false);
+	assert_eq!(
+		proposal.proposed_payload["authority_boundary"]["review_surface"],
+		"consolidation_proposals"
+	);
+	assert_eq!(
+		proposal.proposed_payload["authority_boundary"]["promotion_required_for_memory_authority"],
+		true
+	);
 	assert_eq!(proposal.proposed_payload["source_ref"]["reason"], "changed_claim");
 	assert!(!proposal.markers.staleness.is_empty());
 }

--- a/packages/elf-service/src/knowledge/watch/candidates/proposal.rs
+++ b/packages/elf-service/src/knowledge/watch/candidates/proposal.rs
@@ -48,6 +48,7 @@ pub(in crate::knowledge::watch::candidates) fn candidate_diff(
 			"page_id": page.page.page_id,
 			"section_id": section.section_id,
 			"section_key": section.section_key,
+			"authority_boundary": knowledge_delta_authority_boundary(),
 		}),
 	}
 }
@@ -77,6 +78,7 @@ pub(in crate::knowledge::watch::candidates) fn candidate_proposed_payload(
 		"scope": "project_shared",
 		"importance": 0.65,
 		"confidence": 0.72,
+		"authority_boundary": knowledge_delta_authority_boundary(),
 		"source_ref": {
 			"schema": "elf.knowledge_delta/v1",
 			"reason": reason,
@@ -86,6 +88,18 @@ pub(in crate::knowledge::watch::candidates) fn candidate_proposed_payload(
 			"section_key": section.section_key,
 			"source_mutation_allowed": false,
 		}
+	})
+}
+
+fn knowledge_delta_authority_boundary() -> Value {
+	serde_json::json!({
+		"schema": "elf.knowledge_delta.authority_boundary/v1",
+		"origin_layer": "knowledge_workspace",
+		"authority": "derived_non_authoritative",
+		"review_surface": "consolidation_proposals",
+		"promotion_required_for_memory_authority": true,
+		"direct_memory_ledger_mutation_allowed": false,
+		"source_mutation_allowed": false,
 	})
 }
 


### PR DESCRIPTION
## Summary
- Add explicit authority-boundary metadata to Knowledge Workspace changed-source memory candidates.
- Document that knowledge delta candidates are reviewable consolidation proposals, not Memory Authority mutations.
- Extend unit assertions for the non-authoritative review surface.

## Manual intervention
- Reason: Decodex attempts for XY-1153 failed before producing an effective diff. Attempt 2 and 3 recorded `no_effective_diff`; the Decodex run also hit an app-server output timeout. The retained worktree was clean except Decodex metadata, so I manually implemented the smallest aligned slice in the Decodex worktree.
- Files touched: `packages/elf-service/src/knowledge/watch/candidates/proposal.rs`, `packages/elf-service/src/knowledge/tests_memory.rs`, `packages/elf-service/src/knowledge/tests_helpers.rs`, `docs/spec/system_knowledge_pages_v1.md`, `docs/log.md`.
- Commands run: `cargo make fmt-check`; targeted `cargo test -p elf-service knowledge::tests::tests_memory::memory_candidate_uses_reviewable_consolidation_proposal_contract`; `python3 scripts/check-docs.py`; `git diff --check`; full `cargo make checks`.
- Benchmark/review impact: no benchmark suite added in this slice; full repo checks pass and the new unit coverage strengthens the XY-1153 authority-boundary gate.
- Remaining Decodex handoff state: PR is human/manual-created after Decodex retained-attention failure; Decodex closeout/rebind may still be needed after review/merge.

## Validation
- `cargo make checks`